### PR TITLE
refactor: StringDiffUtil のコスト値をマジックナンバーから名前付き定数に変更

### DIFF
--- a/xyz.hotchpotch.hogandiff/src/main/java/xyz/hotchpotch/hogandiff/core/StringDiffUtil.java
+++ b/xyz.hotchpotch.hogandiff/src/main/java/xyz/hotchpotch/hogandiff/core/StringDiffUtil.java
@@ -21,11 +21,22 @@ import xyz.hotchpotch.hogandiff.util.IntPair;
 public class StringDiffUtil {
     
     // [static members] ++++++++++++++++++++++++++++++++++++++++++++++++++++++++
-    
+
+    /** 挿入・削除1文字あたりのコスト。 */
+    private static final int GAP_COST = 1;
+
+    /**
+     * 置換の内部コスト。{@code GAP_COST * 2} より大きくする必要がある。<br>
+     * この制約により {@link MinimumEditDistanceMatcher} は置換を常に delete+insert に分解し、
+     * {@link #levenshteinDistance} の戻り値（非ペア要素数）が
+     * 標準レーベンシュタイン距離（置換＝削除＋挿入の2操作）と一致する。
+     */
+    private static final int SUBSTITUTION_INTERNAL_COST = 3; // > GAP_COST * 2
+
     private static final Matcher<Integer> codeMatcher = new MinimumEditDistanceMatcher<>(
-            _ -> 1,
-            (x, y) -> x.equals(y) ? 0 : 3);
-    
+            _ -> GAP_COST,
+            (x, y) -> x.equals(y) ? 0 : SUBSTITUTION_INTERNAL_COST);
+
     /**
      * 2つの文字列間のレーベンシュタイン距離を返します。<br>
      * 一文字の挿入と削除はそれぞれ距離1と評価します。


### PR DESCRIPTION
## Summary

- `GAP_COST = 1` と `SUBSTITUTION_INTERNAL_COST = 3` を名前付き定数として定義
- `SUBSTITUTION_INTERNAL_COST > GAP_COST * 2` という不変条件をコメントで明示
- Javadoc の「置換は delete+insert の2操作」という説明と内部コスト設計の関係を説明するコメントを追加

## Background

`MinimumEditDistanceMatcher` は置換コスト > (削除コスト + 挿入コスト) となる場合、置換を常に delete+insert に分解する。
この性質を利用し、`levenshteinDistance()` は非ペア要素数をカウントすることで標準レーベンシュタイン距離（置換=2操作）を返している。

コスト値 `3` がマジックナンバーのままでは、将来のメンテナが「Javadoc には距離2とあるのにコストが3はバグでは？」と誤解し `2` に修正する危険があった。
コストが `GAP_COST * 2` 以下になると DP が substitution と delete+insert を等コストとして扱い、距離カウントが壊れる。

## Test plan

- [ ] `./gradlew test` でリグレッションがないことを確認（ロジック変更なし）

🤖 Generated with [Claude Code](https://claude.com/claude-code)