### PR TITLE
fix: ItemMatcherImpl2 で空セルのみのカラムの重みがゼロになるバグを修正

### DIFF
--- a/xyz.hotchpotch.hogandiff/src/main/java/xyz/hotchpotch/hogandiff/logic/plain/matchers/ItemMatcherImpl2.java
+++ b/xyz.hotchpotch.hogandiff/src/main/java/xyz/hotchpotch/hogandiff/logic/plain/matchers/ItemMatcherImpl2.java
@@ -147,7 +147,7 @@ public class ItemMatcherImpl2 implements ItemMatcher {
             int key = entry.getKey();
             Set<String> strs = entry.getValue();
             int sumLen = strs.parallelStream().mapToInt(String::length).sum();
-            weights[key] = Math.sqrt(sumLen);
+            weights[key] = Math.max(1.0, Math.sqrt(sumLen));
         });
         
         return weights;


### PR DESCRIPTION
## Summary

- `weights()` メソッドで `Math.sqrt(sumLen)` を `Math.max(1.0, Math.sqrt(sumLen))` に変更
- カラム内のすべてのセルが空（`content = ""`）の場合でも最低重み 1.0 を保証

## Problem

カラム内のすべてのセルが空の場合、`sumLen = 0` → `Math.sqrt(0) = 0.0` となり、
そのカラムの `weight` が 0 になっていた。

`gapEvaluator` と `diffEvaluator` は各セルの `weights[colIndex]` を足し合わせてコストを計算するため、
weight = 0 のカラムはコストに一切寄与しない。結果として
「空セルのみのカラムが A シートにあって B シートにない（またはその逆）」という構造的差異が
行マッチングコストに反映されず、誤ったペアリングが生じる可能性があった。

## Fix

`Math.max(1.0, Math.sqrt(sumLen))` とすることで、空カラムでも最低重み 1.0 を保証する。
これにより空カラムの存在が gap コストに反映され、構造的差異が正しく検出される。

## Test plan

- [ ] `./gradlew test` でリグレッションがないことを確認
- [ ] すべてのセルが空のカラムを含む Excel ファイルで比較を実行し、そのカラムが冗長列として検出されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)