### PR TITLE
refactor: ComparatorOfSheetsRC.extractDiffs() の差分判定条件を名前付き変数で明確化

### DIFF
--- a/xyz.hotchpotch.hogandiff/src/main/java/xyz/hotchpotch/hogandiff/logic/plain/ComparatorOfSheetsRC.java
+++ b/xyz.hotchpotch.hogandiff/src/main/java/xyz/hotchpotch/hogandiff/logic/plain/ComparatorOfSheetsRC.java
@@ -130,14 +130,16 @@ public class ComparatorOfSheetsRC implements ComparatorOfSheets {
                     Pair<CellData> cellPair = Side
                             .map(side -> maps.get(side).get(addressPair.get(side)));
                     
-                    return (cellPair.a() != null && cellPair.b() != null
-                            && cellPair.a().dataEquals(cellPair.b())
-                            || cellPair.a() == null && cellPair.b() == null)
-                                    ? null
-                                    : Side.map(side -> cellPair.get(side) != null
-                                            ? cellPair.get(side)
-                                            : CellData.empty(rows.get(side),
-                                                    columns.get(side)));
+                    boolean bothAbsent = cellPair.a() == null && cellPair.b() == null;
+                    boolean bothPresentAndEqual = cellPair.a() != null
+                            && cellPair.b() != null
+                            && cellPair.a().dataEquals(cellPair.b());
+                    if (bothAbsent || bothPresentAndEqual) {
+                        return null;
+                    }
+                    return Side.map(side -> cellPair.get(side) != null
+                            ? cellPair.get(side)
+                            : CellData.empty(rows.get(side), columns.get(side)));
                 }).filter(Objects::nonNull)).toList();
     }
 }


### PR DESCRIPTION
## Summary

- `extractDiffs()` 内の複合三項演算子を `bothAbsent` / `bothPresentAndEqual` の名前付きローカル変数 + `if` 文に分解
- ロジックの変更なし（純粋なリファクタリング）

## Problem

変更前のコード：

```java
return (cellPair.a() != null && cellPair.b() != null
        && cellPair.a().dataEquals(cellPair.b())
        || cellPair.a() == null && cellPair.b() == null)
                ? null
                : Side.map(side -> cellPair.get(side) != null
                        ? cellPair.get(side)
                        : CellData.empty(rows.get(side), columns.get(side)));
```

`&&` と `||` の演算子優先度を意識しながら読まないと、条件の意図を誤解しやすい。
「どういう場合に `null`（差分なし）を返すか」が一目で把握できない。

## Fix

```java
boolean bothAbsent = cellPair.a() == null && cellPair.b() == null;
boolean bothPresentAndEqual = cellPair.a() != null
        && cellPair.b() != null
        && cellPair.a().dataEquals(cellPair.b());
if (bothAbsent || bothPresentAndEqual) {
    return null;
}
return Side.map(side -> cellPair.get(side) != null
        ? cellPair.get(side)
        : CellData.empty(rows.get(side), columns.get(side)));
```

## Test plan

- [ ] `./gradlew test` でリグレッションがないことを確認（ロジック変更なし）

🤖 Generated with [Claude Code](https://claude.com/claude-code)