### PR TITLE
perf: ItemMatcherImpl2 の DP ホットパスから不要な parallelStream を除去

### DIFF
--- a/xyz.hotchpotch.hogandiff/src/main/java/xyz/hotchpotch/hogandiff/logic/plain/matchers/ItemMatcherImpl2.java
+++ b/xyz.hotchpotch.hogandiff/src/main/java/xyz/hotchpotch/hogandiff/logic/plain/matchers/ItemMatcherImpl2.java
@@ -143,10 +143,10 @@ public class ItemMatcherImpl2 implements ItemMatcher {
         int max = map.keySet().stream().mapToInt(i -> i).max().orElse(0);
         double[] weights = new double[max + 1];
         
-        map.entrySet().parallelStream().forEach(entry -> {
+        map.entrySet().forEach(entry -> {
             int key = entry.getKey();
             Set<String> strs = entry.getValue();
-            int sumLen = strs.parallelStream().mapToInt(String::length).sum();
+            int sumLen = strs.stream().mapToInt(String::length).sum();
             weights[key] = Math.max(1.0, Math.sqrt(sumLen));
         });
         
@@ -162,7 +162,7 @@ public class ItemMatcherImpl2 implements ItemMatcher {
     private ToIntFunction<List<CellData>> gapEvaluator(double[] weights) {
         assert weights != null;
         
-        return (list) -> (int) list.parallelStream()
+        return (list) -> (int) list.stream()
                 .mapToInt(horizontal)
                 .mapToDouble(i -> weights[i])
                 .sum();


### PR DESCRIPTION
## Summary

- `gapEvaluator()` の `list.parallelStream()` → `list.stream()` に変更
- `weights()` 内の `map.entrySet().parallelStream().forEach` → `map.entrySet().forEach` に変更
- `weights()` 内の `strs.parallelStream()` → `strs.stream()` に変更

`convert()` (シート全体のセルセットを対象・DP前に1回だけ実行) の `parallelStream()` は変更しない。

## Background

行マッチングの DP は最大 **n × m 回**（1000行シート同士なら 100万セル）`gapEvaluator` を呼び出す。この関数は「1行分のセルリスト（10〜50要素）」の重みを合計するだけだが、`parallelStream()` を使っているため **100万回 × ForkJoinPool 起動コスト** が発生していた。

`weights()` 内の2箇所も同様に、対象が列数分（数十〜数百）の小さな Map/Set であり、スレッド起動オーバーヘッドが実計算を上回っていた。

`stream()` と `parallelStream()` は同じ結果を返すため、ロジック変更はない。

## Test plan

- [x] `./gradlew test` でリグレッションなし確認済み
- [ ] 1000行以上の Excel ファイルで比較を実行して before/after の処理時間を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)