### PR TITLE
fix: UpdateChecker の changeSetting を Platform.runLater に移動し並行書き込みを防止

### DIFF
--- a/xyz.hotchpotch.hogandiff/src/main/java/xyz/hotchpotch/hogandiff/gui/UpdateChecker.java
+++ b/xyz.hotchpotch.hogandiff/src/main/java/xyz/hotchpotch/hogandiff/gui/UpdateChecker.java
@@ -89,7 +89,7 @@ public class UpdateChecker {
                                             .showAndWait();
                         });
                     }
-                    ar.changeSetting(SettingKeys.LAST_CHECK_UPDATES, Instant.now());
+                    Platform.runLater(() -> ar.changeSetting(SettingKeys.LAST_CHECK_UPDATES, Instant.now()));
                 })
                 .exceptionally(throwable -> {
                     ErrorReporter.reportIfEnabled(throwable, "UpdateChecker#checkUpdate-1");

--- a/xyz.hotchpotch.hogandiff/src/main/java/xyz/hotchpotch/hogandiff/logic/plain/matchers/ItemMatcherImpl2.java
+++ b/xyz.hotchpotch.hogandiff/src/main/java/xyz/hotchpotch/hogandiff/logic/plain/matchers/ItemMatcherImpl2.java
@@ -143,10 +143,10 @@ public class ItemMatcherImpl2 implements ItemMatcher {
         int max = map.keySet().stream().mapToInt(i -> i).max().orElse(0);
         double[] weights = new double[max + 1];
         
-        map.entrySet().forEach(entry -> {
+        map.entrySet().parallelStream().forEach(entry -> {
             int key = entry.getKey();
             Set<String> strs = entry.getValue();
-            int sumLen = strs.stream().mapToInt(String::length).sum();
+            int sumLen = strs.parallelStream().mapToInt(String::length).sum();
             weights[key] = Math.sqrt(sumLen);
         });
         
@@ -162,7 +162,7 @@ public class ItemMatcherImpl2 implements ItemMatcher {
     private ToIntFunction<List<CellData>> gapEvaluator(double[] weights) {
         assert weights != null;
         
-        return (list) -> (int) list.stream()
+        return (list) -> (int) list.parallelStream()
                 .mapToInt(horizontal)
                 .mapToDouble(i -> weights[i])
                 .sum();

--- a/xyz.hotchpotch.hogandiff/src/main/java/xyz/hotchpotch/hogandiff/logic/plain/matchers/ItemMatcherImpl2.java
+++ b/xyz.hotchpotch.hogandiff/src/main/java/xyz/hotchpotch/hogandiff/logic/plain/matchers/ItemMatcherImpl2.java
@@ -143,10 +143,10 @@ public class ItemMatcherImpl2 implements ItemMatcher {
         int max = map.keySet().stream().mapToInt(i -> i).max().orElse(0);
         double[] weights = new double[max + 1];
         
-        map.entrySet().parallelStream().forEach(entry -> {
+        map.entrySet().forEach(entry -> {
             int key = entry.getKey();
             Set<String> strs = entry.getValue();
-            int sumLen = strs.parallelStream().mapToInt(String::length).sum();
+            int sumLen = strs.stream().mapToInt(String::length).sum();
             weights[key] = Math.sqrt(sumLen);
         });
         
@@ -162,7 +162,7 @@ public class ItemMatcherImpl2 implements ItemMatcher {
     private ToIntFunction<List<CellData>> gapEvaluator(double[] weights) {
         assert weights != null;
         
-        return (list) -> (int) list.parallelStream()
+        return (list) -> (int) list.stream()
                 .mapToInt(horizontal)
                 .mapToDouble(i -> weights[i])
                 .sum();


### PR DESCRIPTION
## 問題

`UpdateChecker.checkUpdate()` の `CompletableFuture.thenAccept()` は ForkJoinPool スレッドで実行される。
この中で `ar.changeSetting()` を直接呼び出していたため、JavaFX UI スレッドからの `changeSetting()` 呼び出しと並行して `hogandiff.properties` への書き込みが発生しうる状態だった。

2スレッドが同時に `Files.newBufferedWriter(hogandiff.properties)` を呼ぶと、Windows は2つ目のオープンを `java.nio.file.AccessDeniedException` で拒否する。

## 修正内容

`UpdateChecker.java:92` の `ar.changeSetting()` 呼び出しを `Platform.runLater()` でラップし、JavaFX Application Thread から実行されるよう変更した。

```java
// Before
ar.changeSetting(SettingKeys.LAST_CHECK_UPDATES, Instant.now());

// After
Platform.runLater(() -> ar.changeSetting(SettingKeys.LAST_CHECK_UPDATES, Instant.now()));
```

これにより `changeSetting` の全呼び出し箇所が JavaFX Application Thread に統一される（他の約20箇所はすでに UI スレッドから呼ばれていることを確認済み）。

## Test plan

- アプリ起動直後に即座に実行ボタンを押し、`AppResource#storeProperties-1` タグのエラーが報告されないことを確認
- 更新チェック後に `hogandiff.properties` の `LAST_CHECK_UPDATES` が正しく保存されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)