### PR TITLE
fix: ファイル/フォルダ選択ダイアログの初期ディレクトリ存在チェックを追加

### DIFF
--- a/xyz.hotchpotch.hogandiff/src/main/java/xyz/hotchpotch/hogandiff/gui/components/TargetSelectionPane.java
+++ b/xyz.hotchpotch.hogandiff/src/main/java/xyz/hotchpotch/hogandiff/gui/components/TargetSelectionPane.java
@@ -337,10 +337,16 @@ public class TargetSelectionPane extends GridPane implements ChildController {
             
             DirInfo dirInfo = parent.dirInfoPropPair.get(side).getValue();
             if (dirInfo != null) {
-                chooser.setInitialDirectory(dirInfo.dirPath().toFile());
-                
+                File dir = dirInfo.dirPath().toFile();
+                if (dir.isDirectory()) {
+                    chooser.setInitialDirectory(dir);
+                }
+
             } else if (prevSelectedBookPath != null) {
-                chooser.setInitialDirectory(prevSelectedBookPath.toFile().getParentFile());
+                File parentDir = prevSelectedBookPath.toFile().getParentFile();
+                if (parentDir != null && parentDir.isDirectory()) {
+                    chooser.setInitialDirectory(parentDir);
+                }
             }
             
             File selected = chooser.showDialog(getScene().getWindow());
@@ -367,11 +373,17 @@ public class TargetSelectionPane extends GridPane implements ChildController {
             BookInfo bookInfo = parent.bookInfoPropPair.get(side).getValue();
             if (bookInfo != null) {
                 File book = bookInfo.bookPath().toFile();
-                chooser.setInitialDirectory(book.getParentFile());
+                File parentDir = book.getParentFile();
+                if (parentDir != null && parentDir.isDirectory()) {
+                    chooser.setInitialDirectory(parentDir);
+                }
                 chooser.setInitialFileName(book.getName());
-                
+
             } else if (prevSelectedBookPath != null) {
-                chooser.setInitialDirectory(prevSelectedBookPath.toFile().getParentFile());
+                File parentDir = prevSelectedBookPath.toFile().getParentFile();
+                if (parentDir != null && parentDir.isDirectory()) {
+                    chooser.setInitialDirectory(parentDir);
+                }
             }
             
             chooser.getExtensionFilters().add(


### PR DESCRIPTION
## 問題

前回選択したファイル/フォルダのディレクトリが存在しない状態（USB 抜去、ネットワーク切断、OneDrive 同期不可など）でダイアログを開くと、JavaFX が `IllegalArgumentException: Folder parameter must be a valid folder` をスローし、ダイアログが開かなかった。

## 修正内容

`TargetSelectionPane.java` の `chooseBook()` / `chooseDir()` で `setInitialDirectory()` を呼ぶ前に `isDirectory()` チェックを追加した。ディレクトリが存在しない場合は `setInitialDirectory()` を呼ばず、初期ディレクトリなしでダイアログを開く。

修正箇所は計4箇所：
- `chooseDir()` — `dirInfo.dirPath()` の存在チェック
- `chooseDir()` — `prevSelectedBookPath` の親ディレクトリ存在チェック
- `chooseBook()` — `bookInfo.bookPath()` の親ディレクトリ存在チェック
- `chooseBook()` — `prevSelectedBookPath` の親ディレクトリ存在チェック

なお `SettingsPane2.java` は既に `IllegalArgumentException` を try-catch で処理しているため変更なし。

## Test plan

- 存在しないパスを `initialDirectory` に設定した状態でボタンを押し、例外が発生せずダイアログが開くことを確認
- 有効なディレクトリが設定されている場合は従来通りそのディレクトリで開くことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)