### PR TITLE
fix: 作業ディレクトリ削除時に対象ディレクトリが存在しない場合を無視する

### DIFF
--- a/xyz.hotchpotch.hogandiff/src/main/java/xyz/hotchpotch/hogandiff/gui/components/SettingsPane2.java
+++ b/xyz.hotchpotch.hogandiff/src/main/java/xyz/hotchpotch/hogandiff/gui/components/SettingsPane2.java
@@ -198,6 +198,9 @@ public class SettingsPane2 extends VBox implements ChildController {
                         : Files::deleteIfExists;
                 
                 Thread.startVirtualThread(() -> {
+                    if (!Files.isDirectory(workDirBase)) {
+                        return;
+                    }
                     try (Stream<Path> children = Files.list(workDirBase)) {
                         children.forEach(path -> {
                             try {


### PR DESCRIPTION
## 問題

`workDirBase` が存在しない状態で削除ボタンを押すと、`Files.list(workDirBase)` が `java.nio.file.NoSuchFileException` をスローしエラーレポートが送信されていた。

発生シナリオ：
- 手動で削除済みのディレクトリを再度「削除」しようとした
- 設定に保存されていたパスがすでに消えていた（別 PC や別プロファイルで使用したパスが残っていた場合など）

## 修正内容

`Files.list()` 呼び出し前に `Files.isDirectory()` で存在確認を追加し、ディレクトリが存在しない場合は何もせずに処理を終了するよう修正した（3行追加）。

## Test plan

- 存在しないパスを `WORK_DIR_BASE` に設定した状態で削除ボタンを押し、エラーレポートが送信されず正常に終了することを確認
- 存在するディレクトリが設定されている場合は従来通り削除処理が実行されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)