### PR TITLE
feat: 3-way diff の内部モデルを追加

### DIFF
--- a/xyz.hotchpotch.hogandiff/src/main/java/xyz/hotchpotch/hogandiff/gui/dialogs/EditComparisonDialog.java
+++ b/xyz.hotchpotch.hogandiff/src/main/java/xyz/hotchpotch/hogandiff/gui/dialogs/EditComparisonDialog.java
@@ -10,6 +10,7 @@ import xyz.hotchpotch.hogandiff.ErrorReporter;
 import xyz.hotchpotch.hogandiff.Msg;
 import xyz.hotchpotch.hogandiff.logic.PairingInfo;
 import xyz.hotchpotch.hogandiff.logic.PairingInfoBooks;
+import xyz.hotchpotch.hogandiff.logic.PairingInfoBooksTriple;
 import xyz.hotchpotch.hogandiff.logic.PairingInfoDirs;
 
 /**
@@ -51,6 +52,8 @@ public class EditComparisonDialog<T extends PairingInfo> extends Dialog<T> {
                 pane.init();
                 yield pane;
             }
+            case PairingInfoBooksTriple ignored ->
+                throw new UnsupportedOperationException("3-way diff dialog is not yet implemented");
             };
             
             editComparisonDialogPane.getStylesheets().add(

--- a/xyz.hotchpotch.hogandiff/src/main/java/xyz/hotchpotch/hogandiff/logic/PairingInfo.java
+++ b/xyz.hotchpotch.hogandiff/src/main/java/xyz/hotchpotch/hogandiff/logic/PairingInfo.java
@@ -1,7 +1,7 @@
 package xyz.hotchpotch.hogandiff.logic;
 
 public sealed interface PairingInfo
-        permits PairingInfoBooks, PairingInfoDirs {
+        permits PairingInfoBooks, PairingInfoBooksTriple, PairingInfoDirs {
 
     // [static members] ********************************************************
 

--- a/xyz.hotchpotch.hogandiff/src/main/java/xyz/hotchpotch/hogandiff/logic/PairingInfoBooksTriple.java
+++ b/xyz.hotchpotch.hogandiff/src/main/java/xyz/hotchpotch/hogandiff/logic/PairingInfoBooksTriple.java
@@ -1,0 +1,107 @@
+package xyz.hotchpotch.hogandiff.logic;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+import xyz.hotchpotch.hogandiff.core.Matcher;
+import xyz.hotchpotch.hogandiff.util.Pair;
+import xyz.hotchpotch.hogandiff.util.Triple;
+import xyz.hotchpotch.hogandiff.util.Triple.Side;
+
+/**
+ * Excelブック3-way比較情報を表す不変クラスです。<br>
+ * 起源（O）に対するA, Bの差分比較のための情報を保持します。<br>
+ *
+ * @param parentBookInfoTriple 親Excelブック情報（O, A, B）
+ * @param childSheetNameTriples 子シート名の組み合わせ（O, A, Bのトリプル）
+ * @author nmby
+ */
+public final record PairingInfoBooksTriple(
+        Triple<BookInfo> parentBookInfoTriple,
+        List<Triple<String>> childSheetNameTriples)
+        implements PairingInfo {
+
+    // [static members] ********************************************************
+
+    /**
+     * 与えられたマッチャーを使用して新たな {@link PairingInfoBooksTriple} インスタンスを生成します。<br>
+     * <p>
+     * シートのマッチングは O を軸として行います。
+     * O vs A、O vs B をそれぞれマッチングし、O のシート名をキーに結合します。<br>
+     *
+     * @param parentBookInfoTriple 比較対象Excelブックの情報（O, A, B）
+     * @param sheetNamesMatcher シート名の組み合わせを決めるマッチャー
+     * @return 新たなインスタンス
+     * @throws NullPointerException パラメータが {@code null} の場合
+     */
+    public static PairingInfoBooksTriple calculate(
+            Triple<BookInfo> parentBookInfoTriple,
+            Matcher<String> sheetNamesMatcher) {
+
+        Objects.requireNonNull(parentBookInfoTriple);
+        Objects.requireNonNull(sheetNamesMatcher);
+
+        List<String> oSheets = parentBookInfoTriple.hasO()
+                ? parentBookInfoTriple.o().sheetNames()
+                : List.of();
+        List<String> aSheets = parentBookInfoTriple.hasA()
+                ? parentBookInfoTriple.a().sheetNames()
+                : List.of();
+        List<String> bSheets = parentBookInfoTriple.hasB()
+                ? parentBookInfoTriple.b().sheetNames()
+                : List.of();
+
+        // O vs A のマッチング（pair.a() = Oシート名, pair.b() = Aシート名）
+        List<Pair<String>> oaPairs = sheetNamesMatcher.makeItemPairs(oSheets, aSheets);
+
+        // O vs B のマッチング（pair.a() = Oシート名, pair.b() = Bシート名）
+        List<Pair<String>> obPairs = sheetNamesMatcher.makeItemPairs(oSheets, bSheets);
+
+        // Oシート名 → Bシート名 のマップを構築
+        Map<String, String> oToB = new HashMap<>();
+        List<String> bOnlySheets = new ArrayList<>();
+        for (Pair<String> obPair : obPairs) {
+            if (obPair.isPaired()) {
+                oToB.put(obPair.a(), obPair.b());
+            } else if (obPair.isOnlyB()) {
+                bOnlySheets.add(obPair.b());
+            }
+            // isOnlyA（OのみでBに対応なし）は oaPairs 側で処理される
+        }
+
+        // OAペアを基にトリプルを構築
+        List<Triple<String>> triples = new ArrayList<>();
+        for (Pair<String> oaPair : oaPairs) {
+            String oName = oaPair.a();  // Oシート名（A専有の場合はnull）
+            String aName = oaPair.b();  // Aシート名（O専有の場合はnull）
+            String bName = (oName != null) ? oToB.get(oName) : null;  // Bの対応シート名
+            triples.add(Triple.of(oName, aName, bName));
+        }
+
+        // B専有シートを追加
+        for (String bName : bOnlySheets) {
+            triples.add(Triple.ofOnly(Side.B, bName));
+        }
+
+        return new PairingInfoBooksTriple(parentBookInfoTriple, triples);
+    }
+
+    // [instance members] ******************************************************
+
+    /**
+     * コンストラクタ
+     *
+     * @param parentBookInfoTriple Excelブック情報（O, A, B）
+     * @param childSheetNameTriples シート名の組み合わせ
+     * @throws NullPointerException パラメータが {@code null} の場合
+     */
+    public PairingInfoBooksTriple {
+        Objects.requireNonNull(parentBookInfoTriple);
+        Objects.requireNonNull(childSheetNameTriples);
+
+        childSheetNameTriples = List.copyOf(childSheetNameTriples);
+    }
+}

--- a/xyz.hotchpotch.hogandiff/src/main/java/xyz/hotchpotch/hogandiff/logic/Result.java
+++ b/xyz.hotchpotch.hogandiff/src/main/java/xyz/hotchpotch/hogandiff/logic/Result.java
@@ -11,7 +11,7 @@ import xyz.hotchpotch.hogandiff.logic.ResultOfSheets.SheetStats;
  */
 // sealed を使ってみる
 public sealed interface Result
-        permits ResultOfSheets, ResultOfBooks, ResultOfDirs, ResultOfTrees {
+        permits ResultOfSheets, ResultOfSheetsTriple, ResultOfBooks, ResultOfBooksTriple, ResultOfDirs, ResultOfTrees {
     
     // [static members] ********************************************************
     

--- a/xyz.hotchpotch.hogandiff/src/main/java/xyz/hotchpotch/hogandiff/logic/ResultOfBooksTriple.java
+++ b/xyz.hotchpotch.hogandiff/src/main/java/xyz/hotchpotch/hogandiff/logic/ResultOfBooksTriple.java
@@ -1,0 +1,195 @@
+package xyz.hotchpotch.hogandiff.logic;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.function.Predicate;
+
+import xyz.hotchpotch.hogandiff.logic.ResultOfSheets.SheetStats;
+import xyz.hotchpotch.hogandiff.util.Triple;
+
+/**
+ * Excelブックの3-way比較結果を表す不変クラスです。<br>
+ * <p>
+ * 起源（O）に対するA, Bの差分比較結果を保持します。<br>
+ *
+ * @param bookComparison Excelブック3-way比較情報
+ * @param sheetResults Excelシート同士の3-way比較結果（片側だけの欠損トリプルも含む）
+ * @author nmby
+ */
+public record ResultOfBooksTriple(
+        PairingInfoBooksTriple bookComparison,
+        Map<Triple<String>, Optional<ResultOfSheetsTriple>> sheetResults)
+        implements Result {
+
+    // [static members] ********************************************************
+
+    private static final String BR = System.lineSeparator();
+
+    /**
+     * シート名トリプルをユーザー表示用に整形して返します。<br>
+     *
+     * @param id シート名トリプルの識別子
+     * @param sheetNameTriple シート名トリプル
+     * @return シート名トリプルの整形済み文字列
+     * @throws NullPointerException パラメータが {@code null} の場合
+     */
+    public static String formatSheetNamesTriple(
+            String id,
+            Triple<String> sheetNameTriple) {
+
+        Objects.requireNonNull(id);
+        Objects.requireNonNull(sheetNameTriple);
+
+        return "    %s) %s  vs  %s  vs  %s".formatted(
+                id,
+                sheetNameTriple.hasO() ? "O[ " + sheetNameTriple.o() + " ]" : "(なし)",
+                sheetNameTriple.hasA() ? "A[ " + sheetNameTriple.a() + " ]" : "(なし)",
+                sheetNameTriple.hasB() ? "B[ " + sheetNameTriple.b() + " ]" : "(なし)");
+    }
+
+    // [instance members] ******************************************************
+
+    /**
+     * コンストラクタ<br>
+     *
+     * @param bookComparison Excelブック3-way比較情報
+     * @param sheetResults Excelシート同士の3-way比較結果（片側だけの欠損トリプルも含む）
+     * @throws NullPointerException パラメータが {@code null} の場合
+     */
+    public ResultOfBooksTriple {
+        Objects.requireNonNull(bookComparison);
+        Objects.requireNonNull(sheetResults);
+
+        sheetResults = Map.copyOf(sheetResults);
+    }
+
+    /**
+     * この比較結果における差分の有無を返します。<br>
+     *
+     * @return 差分ありの場合は {@code true}
+     */
+    public boolean hasDiff() {
+        return bookComparison.childSheetNameTriples().stream()
+                .map(sheetResults::get)
+                .anyMatch(r -> r == null || r.isEmpty() || r.get().hasDiff());
+    }
+
+    /**
+     * 比較結果を端的に表す差分サマリを返します。<br>
+     *
+     * @return 比較結果を端的に表す差分サマリ
+     */
+    public String getDiffSimpleSummary() {
+        int diffSheets = (int) bookComparison.childSheetNameTriples().stream()
+                .filter(Triple::isPaired)
+                .map(sheetResults::get)
+                .map(Optional::get)
+                .filter(ResultOfSheetsTriple::hasDiff)
+                .count();
+        int gapSheets = (int) bookComparison.childSheetNameTriples().stream()
+                .filter(Predicate.not(Triple::isPaired))
+                .count();
+
+        if (diffSheets == 0 && gapSheets == 0) {
+            return "差分なし";
+        }
+
+        StringBuilder str = new StringBuilder();
+        if (0 < diffSheets) {
+            str.append("%dシートに差分あり".formatted(diffSheets));
+        }
+        if (0 < gapSheets) {
+            if (!str.isEmpty()) {
+                str.append(", ");
+            }
+            str.append("%dシートが片側のみに存在".formatted(gapSheets));
+        }
+        return str.toString();
+    }
+
+    /**
+     * 比較結果の差分サマリを返します。<br>
+     *
+     * @return 比較結果の差分サマリ
+     */
+    public String getDiffSummary() {
+        return getDiffText(sResult -> "  -  " + sResult.getDiffSummary());
+    }
+
+    /**
+     * 比較結果の差分詳細を返します。<br>
+     *
+     * @return 比較結果の差分詳細
+     */
+    public String getDiffDetail() {
+        return getDiffText(sResult -> BR + sResult.getDiffDetail().indent(8).replace("\n", BR));
+    }
+
+    private String getDiffText(Function<ResultOfSheetsTriple, String> diffDescriptor) {
+        StringBuilder str = new StringBuilder();
+
+        for (int i = 0; i < bookComparison.childSheetNameTriples().size(); i++) {
+            Triple<String> sheetNameTriple = bookComparison.childSheetNameTriples().get(i);
+            Optional<ResultOfSheetsTriple> sResult = sheetResults.get(sheetNameTriple);
+
+            if (sResult == null || !sheetNameTriple.isPaired()
+                    || sResult.isEmpty() || !sResult.get().hasDiff()) {
+                continue;
+            }
+
+            str.append(formatSheetNamesTriple(Integer.toString(i + 1), sheetNameTriple));
+            str.append(diffDescriptor.apply(sResult.get()));
+            str.append(BR);
+        }
+
+        return str.isEmpty()
+                ? "    差分なし" + BR + BR
+                : str.toString();
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder str = new StringBuilder();
+
+        Triple<BookInfo> bookInfoTriple = bookComparison.parentBookInfoTriple();
+        if (bookInfoTriple.isIdentical()) {
+            str.append("ブック: ").append(bookInfoTriple.o().bookPath()).append(BR);
+        } else {
+            if (bookInfoTriple.hasO()) {
+                str.append("[O] ").append(bookInfoTriple.o().bookPath()).append(BR);
+            }
+            if (bookInfoTriple.hasA()) {
+                str.append("[A] ").append(bookInfoTriple.a().bookPath()).append(BR);
+            }
+            if (bookInfoTriple.hasB()) {
+                str.append("[B] ").append(bookInfoTriple.b().bookPath()).append(BR);
+            }
+        }
+
+        for (int i = 0; i < bookComparison.childSheetNameTriples().size(); i++) {
+            Triple<String> sheetNameTriple = bookComparison.childSheetNameTriples().get(i);
+            str.append(formatSheetNamesTriple(Integer.toString(i + 1), sheetNameTriple)).append(BR);
+        }
+
+        str.append(BR);
+        str.append("=== 差分サマリ ===").append(BR);
+        str.append(getDiffSummary()).append(BR);
+        str.append("=== 差分詳細 ===").append(BR);
+        str.append(getDiffDetail());
+
+        return str.toString();
+    }
+
+    @Override
+    public List<SheetStats> sheetStats() {
+        return sheetResults.values().stream()
+                .filter(Optional::isPresent)
+                .map(Optional::get)
+                .map(ResultOfSheetsTriple::sheetStats)
+                .flatMap(List::stream)
+                .toList();
+    }
+}

--- a/xyz.hotchpotch.hogandiff/src/main/java/xyz/hotchpotch/hogandiff/logic/ResultOfSheetsTriple.java
+++ b/xyz.hotchpotch.hogandiff/src/main/java/xyz/hotchpotch/hogandiff/logic/ResultOfSheetsTriple.java
@@ -1,0 +1,165 @@
+package xyz.hotchpotch.hogandiff.logic;
+
+import java.util.List;
+import java.util.Objects;
+
+import xyz.hotchpotch.hogandiff.logic.ResultOfSheets.Piece;
+import xyz.hotchpotch.hogandiff.logic.ResultOfSheets.SheetStats;
+import xyz.hotchpotch.hogandiff.util.Pair;
+import xyz.hotchpotch.hogandiff.util.Triple;
+
+/**
+ * Excelシートの3-way比較結果を表す不変クラスです。<br>
+ * <p>
+ * 起源（O）に対するA, Bそれぞれの2-way比較結果（O vs A、O vs B）を保持します。<br>
+ *
+ * @author nmby
+ */
+public final class ResultOfSheetsTriple implements Result {
+
+    // [static members] ********************************************************
+
+    private static final String BR = System.lineSeparator();
+
+    // [instance members] ******************************************************
+
+    /**
+     * O vs A の比較結果。<br>
+     * Pair.Side.A が O 側、Pair.Side.B が A 側に対応します。
+     */
+    private final ResultOfSheets resultOA;
+
+    /**
+     * O vs B の比較結果。<br>
+     * Pair.Side.A が O 側、Pair.Side.B が B 側に対応します。
+     */
+    private final ResultOfSheets resultOB;
+
+    /**
+     * コンストラクタ<br>
+     *
+     * @param resultOA O vs A の比較結果（Pair.Side.A = O, Pair.Side.B = A）
+     * @param resultOB O vs B の比較結果（Pair.Side.A = O, Pair.Side.B = B）
+     * @throws NullPointerException パラメータが {@code null} の場合
+     */
+    public ResultOfSheetsTriple(
+            ResultOfSheets resultOA,
+            ResultOfSheets resultOB) {
+
+        Objects.requireNonNull(resultOA);
+        Objects.requireNonNull(resultOB);
+
+        this.resultOA = resultOA;
+        this.resultOB = resultOB;
+    }
+
+    /**
+     * O vs A の比較結果を返します。<br>
+     *
+     * @return O vs A の比較結果
+     */
+    public ResultOfSheets resultOA() {
+        return resultOA;
+    }
+
+    /**
+     * O vs B の比較結果を返します。<br>
+     *
+     * @return O vs B の比較結果
+     */
+    public ResultOfSheets resultOB() {
+        return resultOB;
+    }
+
+    /**
+     * 指定された側のシートに関する差分内容を返します。<br>
+     * <p>
+     * <ul>
+     * <li>O側：AおよびBとの差分をすべて含む {@link Piece} を返します。</li>
+     * <li>A側：O vs A 比較のA側 {@link Piece} を返します。</li>
+     * <li>B側：O vs B 比較のB側 {@link Piece} を返します。</li>
+     * </ul>
+     *
+     * @param side シートの側
+     * @return 指定された側のシートに関する差分内容
+     * @throws NullPointerException パラメータが {@code null} の場合
+     */
+    public Piece getPiece(Triple.Side side) {
+        Objects.requireNonNull(side);
+
+        return switch (side) {
+            case O -> resultOA.getPiece(Pair.Side.A);
+            case A -> resultOA.getPiece(Pair.Side.B);
+            case B -> resultOB.getPiece(Pair.Side.B);
+        };
+    }
+
+    /**
+     * この比較結果における差分の有無を返します。<br>
+     *
+     * @return 差分ありの場合は {@code true}
+     */
+    public boolean hasDiff() {
+        return resultOA.hasDiff() || resultOB.hasDiff();
+    }
+
+    /**
+     * 比較結果の差分サマリを返します。<br>
+     *
+     * @return 比較結果の差分サマリ
+     */
+    public String getDiffSummary() {
+        if (!hasDiff()) {
+            return "差分なし";
+        }
+
+        StringBuilder str = new StringBuilder();
+        if (resultOA.hasDiff()) {
+            str.append("O vs A: ").append(resultOA.getDiffSummary());
+        }
+        if (resultOB.hasDiff()) {
+            if (!str.isEmpty()) {
+                str.append("  /  ");
+            }
+            str.append("O vs B: ").append(resultOB.getDiffSummary());
+        }
+        return str.toString();
+    }
+
+    /**
+     * 比較結果の差分詳細を返します。<br>
+     *
+     * @return 比較結果の差分詳細
+     */
+    public String getDiffDetail() {
+        if (!hasDiff()) {
+            return "差分なし";
+        }
+
+        StringBuilder str = new StringBuilder();
+        if (resultOA.hasDiff()) {
+            str.append("[O vs A]").append(BR);
+            str.append(resultOA.getDiffDetail());
+        }
+        if (resultOB.hasDiff()) {
+            if (!str.isEmpty()) {
+                str.append(BR);
+            }
+            str.append("[O vs B]").append(BR);
+            str.append(resultOB.getDiffDetail());
+        }
+        return str.toString();
+    }
+
+    @Override
+    public String toString() {
+        return getDiffDetail();
+    }
+
+    @Override
+    public List<SheetStats> sheetStats() {
+        return List.of(
+                resultOA.sheetStats().get(0),
+                resultOB.sheetStats().get(0));
+    }
+}

--- a/xyz.hotchpotch.hogandiff/src/main/java/xyz/hotchpotch/hogandiff/util/Triple.java
+++ b/xyz.hotchpotch.hogandiff/src/main/java/xyz/hotchpotch/hogandiff/util/Triple.java
@@ -1,0 +1,319 @@
+package xyz.hotchpotch.hogandiff.util;
+
+import java.util.NoSuchElementException;
+import java.util.Objects;
+import java.util.function.Consumer;
+import java.util.function.Function;
+
+import xyz.hotchpotch.hogandiff.util.function.UnsafeFunction;
+
+/**
+ * 同型の3つの要素を保持する不変コンテナです。<br>
+ *
+ * @param <T> 要素の型
+ * @param o 起源（origin）の要素
+ * @param a 要素a
+ * @param b 要素b
+ * @author nmby
+ */
+public record Triple<T>(T o, T a, T b) {
+
+    // [static members] ********************************************************
+
+    /**
+     * トリプルのどの側かを表す列挙型です。<br>
+     *
+     * @author nmby
+     */
+    public static enum Side {
+
+        // [static members] ----------------------------------------------------
+
+        /** O-side（起源） */
+        O,
+
+        /** A-side */
+        A,
+
+        /** B-side */
+        B;
+
+        /**
+         * 各側に関数を適用して得られる要素からなるトリプルを返します。<br>
+         *
+         * @param <T> 新たな要素の型
+         * @param mapper 各側に適用する関数
+         * @return 新たなトリプル
+         * @throws NullPointerException パラメータが {@code null} の場合
+         */
+        public static <T> Triple<T> map(Function<Side, ? extends T> mapper) {
+            Objects.requireNonNull(mapper);
+
+            return new Triple<>(
+                    mapper.apply(O),
+                    mapper.apply(A),
+                    mapper.apply(B));
+        }
+
+        /**
+         * 各側に関数を適用して得られる要素からなるトリプルを返します。<br>
+         *
+         * @param <T> 新たな要素の型
+         * @param <E> {@code mapper} がスローしうるチェック例外の型
+         * @param mapper 各側に適用する関数
+         * @return 新たなトリプル
+         * @throws NullPointerException パラメータが {@code null} の場合
+         */
+        public static <T, E extends Exception> Triple<T> unsafeMap(
+                UnsafeFunction<Side, ? extends T, E> mapper) throws E {
+
+            Objects.requireNonNull(mapper);
+
+            return new Triple<>(
+                    mapper.apply(O),
+                    mapper.apply(A),
+                    mapper.apply(B));
+        }
+
+        /**
+         * 各側に指定されたオペレーションを適用します。<br>
+         *
+         * @param operation 各側に適用するオペレーション
+         * @throws NullPointerException パラメータが {@code null} の場合
+         */
+        public static void forEach(Consumer<Side> operation) {
+            Objects.requireNonNull(operation);
+
+            operation.accept(O);
+            operation.accept(A);
+            operation.accept(B);
+        }
+    }
+
+    /**
+     * 新しいトリプルを返します。<br>
+     *
+     * @param <T> 要素の型
+     * @param o 起源（origin）の要素
+     * @param a 要素a
+     * @param b 要素b
+     * @return 新しいトリプル
+     */
+    public static <T> Triple<T> of(T o, T a, T b) {
+        return new Triple<>(o, a, b);
+    }
+
+    /**
+     * 指定された側だけの要素を持つ新しいトリプルを返します。<br>
+     *
+     * @param <T> 要素の型
+     * @param side 要素の側
+     * @param value 指定された側の要素
+     * @return 新しいトリプル
+     * @throws NullPointerException {@code side} が {@code null} の場合
+     */
+    public static <T> Triple<T> ofOnly(Side side, T value) {
+        Objects.requireNonNull(side);
+        return switch (side) {
+            case O -> new Triple<>(value, null, null);
+            case A -> new Triple<>(null, value, null);
+            case B -> new Triple<>(null, null, value);
+        };
+    }
+
+    /**
+     * 空のトリプルを返します。<br>
+     *
+     * @param <T> 要素の型
+     * @return 空のトリプル
+     */
+    public static <T> Triple<T> empty() {
+        return new Triple<>(null, null, null);
+    }
+
+    // [instance members] ******************************************************
+
+    @Override
+    public String toString() {
+        return "(%s, %s, %s)".formatted(o, a, b);
+    }
+
+    /**
+     * 指定された側の要素がある場合はその値を返し、そうでない場合は例外をスローします。<br>
+     *
+     * @param side 要素の側
+     * @return 指定された側の要素
+     * @throws NullPointerException パラメータが {@code null} の場合
+     * @throws NoSuchElementException 指定された側の要素が無い場合
+     */
+    public T get(Side side) {
+        Objects.requireNonNull(side);
+
+        T value = switch (side) {
+            case O -> o;
+            case A -> a;
+            case B -> b;
+        };
+        if (value == null) {
+            throw new NoSuchElementException();
+        }
+        return value;
+    }
+
+    /**
+     * 要素oが存在するかを返します。<br>
+     *
+     * @return 要素oが存在する場合は {@code true}
+     */
+    public boolean hasO() {
+        return o != null;
+    }
+
+    /**
+     * 要素aが存在するかを返します。<br>
+     *
+     * @return 要素aが存在する場合は {@code true}
+     */
+    public boolean hasA() {
+        return a != null;
+    }
+
+    /**
+     * 要素bが存在するかを返します。<br>
+     *
+     * @return 要素bが存在する場合は {@code true}
+     */
+    public boolean hasB() {
+        return b != null;
+    }
+
+    /**
+     * 指定された側の要素が存在するかを返します。<br>
+     *
+     * @param side 要素の側
+     * @return 指定された側の要素が存在する場合は {@code true}
+     * @throws NullPointerException パラメータが {@code null} の場合
+     */
+    public boolean has(Side side) {
+        Objects.requireNonNull(side);
+
+        return switch (side) {
+            case O -> o != null;
+            case A -> a != null;
+            case B -> b != null;
+        };
+    }
+
+    /**
+     * 要素o, 要素a, 要素bがすべて存在するかを返します。<br>
+     *
+     * @return 全要素が存在する場合は {@code true}
+     */
+    public boolean isPaired() {
+        return o != null && a != null && b != null;
+    }
+
+    /**
+     * 要素oだけが存在するかを返します。<br>
+     *
+     * @return 要素oだけが存在する場合は {@code true}
+     */
+    public boolean isOnlyO() {
+        return o != null && a == null && b == null;
+    }
+
+    /**
+     * 要素aだけが存在するかを返します。<br>
+     *
+     * @return 要素aだけが存在する場合は {@code true}
+     */
+    public boolean isOnlyA() {
+        return o == null && a != null && b == null;
+    }
+
+    /**
+     * 要素bだけが存在するかを返します。<br>
+     *
+     * @return 要素bだけが存在する場合は {@code true}
+     */
+    public boolean isOnlyB() {
+        return o == null && a == null && b != null;
+    }
+
+    /**
+     * このトリプルが空かを返します。<br>
+     *
+     * @return このトリプルが空の場合は {@code true}
+     */
+    public boolean isEmpty() {
+        return o == null && a == null && b == null;
+    }
+
+    /**
+     * 要素o、要素a、要素bがすべて同じであるかを返します。<br>
+     *
+     * @return 全要素が同じ場合は {@code true}
+     */
+    public boolean isIdentical() {
+        return Objects.equals(o, a) && Objects.equals(a, b);
+    }
+
+    /**
+     * このトリプルの各要素に関数を適用して得られる新たな要素からなるトリプルを返します。<br>
+     *
+     * @param <U> 新たな要素の型
+     * @param mapper 各要素に適用する関数
+     * @return 新たなトリプル
+     * @throws NullPointerException パラメータが {@code null} の場合
+     */
+    public <U> Triple<U> map(Function<? super T, ? extends U> mapper) {
+        Objects.requireNonNull(mapper);
+
+        return new Triple<>(
+                o == null ? null : mapper.apply(o),
+                a == null ? null : mapper.apply(a),
+                b == null ? null : mapper.apply(b));
+    }
+
+    /**
+     * このトリプルの各要素に関数を適用して得られる新たな要素からなるトリプルを返します。<br>
+     *
+     * @param <U> 新たな要素の型
+     * @param <E> {@code mapper} がスローしうるチェック例外の型
+     * @param mapper 各要素に適用する関数
+     * @return 新たなトリプル
+     * @throws NullPointerException パラメータが {@code null} の場合
+     * @throws E {@code mapper.apply} が失敗した場合
+     */
+    public <U, E extends Exception> Triple<U> unsafeMap(
+            UnsafeFunction<? super T, ? extends U, E> mapper) throws E {
+
+        Objects.requireNonNull(mapper);
+
+        return new Triple<>(
+                o == null ? null : mapper.apply(o),
+                a == null ? null : mapper.apply(a),
+                b == null ? null : mapper.apply(b));
+    }
+
+    /**
+     * このトリプルの各要素に指定されたオペレーションを適用します。
+     * 要素が存在しない場合はオペレーションを適用しません。<br>
+     *
+     * @param operation 各要素に適用するオペレーション
+     * @throws NullPointerException パラメータが {@code null} の場合
+     */
+    public void forEach(Consumer<? super T> operation) {
+        Objects.requireNonNull(operation);
+
+        if (o != null) {
+            operation.accept(o);
+        }
+        if (a != null) {
+            operation.accept(a);
+        }
+        if (b != null) {
+            operation.accept(b);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- `util/Triple<T>` を新規作成 — `Pair<T>` の3要素版（Side: O / A / B）
- `logic/PairingInfoBooksTriple` を新規作成 — O を軸にシートを O vs A、O vs B でマッチングし結合する比較情報
- `logic/ResultOfSheetsTriple` を新規作成 — OvsA・OvsB の `ResultOfSheets` を保持し、`getPiece(Triple.Side)` で各側の差分を取得可能
- `logic/ResultOfBooksTriple` を新規作成 — シートトリプルごとの比較結果マップ
- `PairingInfo` / `Result` の sealed permits に新クラスを追加
- `EditComparisonDialog` に `PairingInfoBooksTriple` の switch case を追加（未実装 → `UnsupportedOperationException`）

## 方針

- GUI・タスク層（`CompareTask` 系、メニュー、画面）には**手を加えていない**
- 外部仕様に影響しない内部モデルのみを追加する段階的実装の第1弾
- 比較アルゴリズム: O vs A / O vs B を既存の2-way比較で個別に実行し、結果を `ResultOfSheetsTriple` で保持する設計

## Test plan

- [x] `../gradlew compileJava` — コンパイルエラーなし
- [x] `../gradlew test` — 全テスト PASS
- [ ] 次ステップ: `CompareTaskBooksTriple` の実装、GUI への 3-way diff メニュー追加

🤖 Generated with [Claude Code](https://claude.com/claude-code)