### PR TITLE
feat: 3-way ブック比較タスクの実装（CompareTaskBooksTriple）

### DIFF
--- a/xyz.hotchpotch.hogandiff/src/main/java/xyz/hotchpotch/hogandiff/AppMenu.java
+++ b/xyz.hotchpotch.hogandiff/src/main/java/xyz/hotchpotch/hogandiff/AppMenu.java
@@ -6,8 +6,10 @@ import java.util.function.Predicate;
 
 import javafx.concurrent.Task;
 import xyz.hotchpotch.hogandiff.logic.PairingInfoBooks;
+import xyz.hotchpotch.hogandiff.logic.PairingInfoBooksTriple;
 import xyz.hotchpotch.hogandiff.logic.PairingInfoDirs;
 import xyz.hotchpotch.hogandiff.tasks.CompareTaskBooks;
+import xyz.hotchpotch.hogandiff.tasks.CompareTaskBooksTriple;
 import xyz.hotchpotch.hogandiff.tasks.CompareTaskDirs;
 import xyz.hotchpotch.hogandiff.tasks.CompareTaskSheets;
 import xyz.hotchpotch.hogandiff.tasks.CompareTaskTrees;
@@ -97,27 +99,48 @@ public enum AppMenu {
      * 処理対象のフォルダ／Excelブック／シートの指定が妥当なものかを確認します。<br>
      * 具体的には、2つの比較対象が同じものの場合は {@code false} を、
      * それ以外の場合は {@code true} を返します。<br>
-     * 
+     *
      * @param settings 設定
      * @return 比較対象の指定が妥当な場合は {@code true}
      * @throws NullPointerException パラメータが {@code null} の場合
      */
     public boolean isValidTargets(Settings settings) {
         Objects.requireNonNull(settings);
-        
-        return targetValidator.test(settings);
+
+        DiffMode mode = settings.get(SettingKeys.CURR_DIFF_MODE);
+        return switch (mode) {
+            case TWO_WAY -> targetValidator.test(settings);
+            case THREE_WAY -> switch (this) {
+                case COMPARE_BOOKS -> {
+                    PairingInfoBooksTriple info =
+                            settings.get(SettingKeys.CURR_BOOK_COMPARE_INFO_TRIPLE);
+                    Objects.requireNonNull(info);
+                    yield !info.parentBookInfoTriple().isIdentical();
+                }
+                default -> throw new UnsupportedOperationException(
+                        "3-way diff not supported for " + this);
+            };
+        };
     }
-    
+
     /**
      * このメニューを実行するためのタスクを生成して返します。<br>
-     * 
+     *
      * @param settings 設定
      * @return 新しいタスク
      * @throws NullPointerException パラメータが {@code null} の場合
      */
     public Task<Void> getTask(Settings settings) {
         Objects.requireNonNull(settings);
-        
-        return taskFactory.apply(settings);
+
+        DiffMode mode = settings.get(SettingKeys.CURR_DIFF_MODE);
+        return switch (mode) {
+            case TWO_WAY -> taskFactory.apply(settings);
+            case THREE_WAY -> switch (this) {
+                case COMPARE_BOOKS -> new CompareTaskBooksTriple(settings);
+                default -> throw new UnsupportedOperationException(
+                        "3-way diff not supported for " + this);
+            };
+        };
     }
 }

--- a/xyz.hotchpotch.hogandiff/src/main/java/xyz/hotchpotch/hogandiff/DiffMode.java
+++ b/xyz.hotchpotch.hogandiff/src/main/java/xyz/hotchpotch/hogandiff/DiffMode.java
@@ -1,0 +1,15 @@
+package xyz.hotchpotch.hogandiff;
+
+/**
+ * 比較モードを表す列挙型です。<br>
+ *
+ * @author nmby
+ */
+public enum DiffMode {
+
+    /** 2-way diff（A と B の比較） */
+    TWO_WAY,
+
+    /** 3-way diff（起源 O に対する A と B の差分比較） */
+    THREE_WAY
+}

--- a/xyz.hotchpotch.hogandiff/src/main/java/xyz/hotchpotch/hogandiff/SettingKeys.java
+++ b/xyz.hotchpotch.hogandiff/src/main/java/xyz/hotchpotch/hogandiff/SettingKeys.java
@@ -15,6 +15,7 @@ import java.util.stream.Stream;
 import org.apache.poi.ss.usermodel.IndexedColors;
 
 import xyz.hotchpotch.hogandiff.logic.PairingInfoBooks;
+import xyz.hotchpotch.hogandiff.logic.PairingInfoBooksTriple;
 import xyz.hotchpotch.hogandiff.logic.PairingInfoDirs;
 import xyz.hotchpotch.hogandiff.util.Pair;
 import xyz.hotchpotch.hogandiff.util.Settings.Key;
@@ -113,6 +114,14 @@ public class SettingKeys {
             AppMenu::toString,
             AppMenu::valueOf,
             false);
+
+    /** 今回の実行における diff モード */
+    public static final Key<DiffMode> CURR_DIFF_MODE = new Key<>(
+            "current.diffMode",
+            () -> DiffMode.TWO_WAY,
+            DiffMode::toString,
+            DiffMode::valueOf,
+            false);
     
     /** 比較対象Excelブックたちの読み取りパスワード */
     public static final Key<Map<Path, String>> CURR_READ_PASSWORDS = new Key<>(
@@ -173,6 +182,14 @@ public class SettingKeys {
             () -> null,
             PairingInfoDirs::toString,
             decodeNotSupported("cannnot decode."),
+            false);
+
+    /** 今回の実行における 3-way ブック比較情報 */
+    public static final Key<PairingInfoBooksTriple> CURR_BOOK_COMPARE_INFO_TRIPLE = new Key<>(
+            "current.bookComparisonTriple",
+            () -> null,
+            PairingInfoBooksTriple::toString,
+            decodeNotSupported("cannot decode."),
             false);
     
     /** 行の挿入／削除を考慮するか */
@@ -276,6 +293,30 @@ public class SettingKeys {
             color -> "#%02x%02x%02x".formatted(color.getRed(), color.getGreen(), color.getBlue()),
             Color::decode,
             false);
+
+    /** 3-way 比較結果レポートにおける、O ファイル上の A-only 差分に着ける色（赤系） */
+    public static final Key<Short> THREE_WAY_DIFF_COLOR_A = new Key<>(
+            "report.threeWayDiffColorA",
+            () -> IndexedColors.CORAL.getIndex(),
+            String::valueOf,
+            Short::valueOf,
+            true);
+
+    /** 3-way 比較結果レポートにおける、O ファイル上の B-only 差分に着ける色（青系） */
+    public static final Key<Short> THREE_WAY_DIFF_COLOR_B = new Key<>(
+            "report.threeWayDiffColorB",
+            () -> IndexedColors.LIGHT_TURQUOISE.getIndex(),
+            String::valueOf,
+            Short::valueOf,
+            true);
+
+    /** 3-way 比較結果レポートにおける、O ファイル上の競合差分に着ける色（紫系） */
+    public static final Key<Short> THREE_WAY_DIFF_COLOR_CONFLICT = new Key<>(
+            "report.threeWayDiffColorConflict",
+            () -> IndexedColors.VIOLET.getIndex(),
+            String::valueOf,
+            Short::valueOf,
+            true);
     
     /** レポートオプション：差分個所に色を付けたシートを表示するか */
     public static final Key<Boolean> SHOW_PAINTED_SHEETS = new Key<>(

--- a/xyz.hotchpotch.hogandiff/src/main/java/xyz/hotchpotch/hogandiff/gui/dialogs/EditComparisonDialog.java
+++ b/xyz.hotchpotch.hogandiff/src/main/java/xyz/hotchpotch/hogandiff/gui/dialogs/EditComparisonDialog.java
@@ -10,6 +10,7 @@ import xyz.hotchpotch.hogandiff.ErrorReporter;
 import xyz.hotchpotch.hogandiff.Msg;
 import xyz.hotchpotch.hogandiff.logic.PairingInfo;
 import xyz.hotchpotch.hogandiff.logic.PairingInfoBooks;
+import xyz.hotchpotch.hogandiff.logic.PairingInfoBooksTriple;
 import xyz.hotchpotch.hogandiff.logic.PairingInfoDirs;
 
 /**
@@ -51,6 +52,8 @@ public class EditComparisonDialog<T extends PairingInfo> extends Dialog<T> {
                 pane.init();
                 yield pane;
             }
+            case PairingInfoBooksTriple ignored ->
+                throw new UnsupportedOperationException("3-way diff dialog is not yet implemented");
             };
             
             editComparisonDialogPane.getStylesheets().add(

--- a/xyz.hotchpotch.hogandiff/src/main/java/xyz/hotchpotch/hogandiff/logic/PairingInfo.java
+++ b/xyz.hotchpotch.hogandiff/src/main/java/xyz/hotchpotch/hogandiff/logic/PairingInfo.java
@@ -1,7 +1,7 @@
 package xyz.hotchpotch.hogandiff.logic;
 
 public sealed interface PairingInfo
-        permits PairingInfoBooks, PairingInfoDirs {
+        permits PairingInfoBooks, PairingInfoBooksTriple, PairingInfoDirs {
 
     // [static members] ********************************************************
 

--- a/xyz.hotchpotch.hogandiff/src/main/java/xyz/hotchpotch/hogandiff/logic/PairingInfoBooksTriple.java
+++ b/xyz.hotchpotch.hogandiff/src/main/java/xyz/hotchpotch/hogandiff/logic/PairingInfoBooksTriple.java
@@ -1,0 +1,107 @@
+package xyz.hotchpotch.hogandiff.logic;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+import xyz.hotchpotch.hogandiff.core.Matcher;
+import xyz.hotchpotch.hogandiff.util.Pair;
+import xyz.hotchpotch.hogandiff.util.Triple;
+import xyz.hotchpotch.hogandiff.util.Triple.Side;
+
+/**
+ * Excelブック3-way比較情報を表す不変クラスです。<br>
+ * 起源（O）に対するA, Bの差分比較のための情報を保持します。<br>
+ *
+ * @param parentBookInfoTriple 親Excelブック情報（O, A, B）
+ * @param childSheetNameTriples 子シート名の組み合わせ（O, A, Bのトリプル）
+ * @author nmby
+ */
+public final record PairingInfoBooksTriple(
+        Triple<BookInfo> parentBookInfoTriple,
+        List<Triple<String>> childSheetNameTriples)
+        implements PairingInfo {
+
+    // [static members] ********************************************************
+
+    /**
+     * 与えられたマッチャーを使用して新たな {@link PairingInfoBooksTriple} インスタンスを生成します。<br>
+     * <p>
+     * シートのマッチングは O を軸として行います。
+     * O vs A、O vs B をそれぞれマッチングし、O のシート名をキーに結合します。<br>
+     *
+     * @param parentBookInfoTriple 比較対象Excelブックの情報（O, A, B）
+     * @param sheetNamesMatcher シート名の組み合わせを決めるマッチャー
+     * @return 新たなインスタンス
+     * @throws NullPointerException パラメータが {@code null} の場合
+     */
+    public static PairingInfoBooksTriple calculate(
+            Triple<BookInfo> parentBookInfoTriple,
+            Matcher<String> sheetNamesMatcher) {
+
+        Objects.requireNonNull(parentBookInfoTriple);
+        Objects.requireNonNull(sheetNamesMatcher);
+
+        List<String> oSheets = parentBookInfoTriple.hasO()
+                ? parentBookInfoTriple.o().sheetNames()
+                : List.of();
+        List<String> aSheets = parentBookInfoTriple.hasA()
+                ? parentBookInfoTriple.a().sheetNames()
+                : List.of();
+        List<String> bSheets = parentBookInfoTriple.hasB()
+                ? parentBookInfoTriple.b().sheetNames()
+                : List.of();
+
+        // O vs A のマッチング（pair.a() = Oシート名, pair.b() = Aシート名）
+        List<Pair<String>> oaPairs = sheetNamesMatcher.makeItemPairs(oSheets, aSheets);
+
+        // O vs B のマッチング（pair.a() = Oシート名, pair.b() = Bシート名）
+        List<Pair<String>> obPairs = sheetNamesMatcher.makeItemPairs(oSheets, bSheets);
+
+        // Oシート名 → Bシート名 のマップを構築
+        Map<String, String> oToB = new HashMap<>();
+        List<String> bOnlySheets = new ArrayList<>();
+        for (Pair<String> obPair : obPairs) {
+            if (obPair.isPaired()) {
+                oToB.put(obPair.a(), obPair.b());
+            } else if (obPair.isOnlyB()) {
+                bOnlySheets.add(obPair.b());
+            }
+            // isOnlyA（OのみでBに対応なし）は oaPairs 側で処理される
+        }
+
+        // OAペアを基にトリプルを構築
+        List<Triple<String>> triples = new ArrayList<>();
+        for (Pair<String> oaPair : oaPairs) {
+            String oName = oaPair.a();  // Oシート名（A専有の場合はnull）
+            String aName = oaPair.b();  // Aシート名（O専有の場合はnull）
+            String bName = (oName != null) ? oToB.get(oName) : null;  // Bの対応シート名
+            triples.add(Triple.of(oName, aName, bName));
+        }
+
+        // B専有シートを追加
+        for (String bName : bOnlySheets) {
+            triples.add(Triple.ofOnly(Side.B, bName));
+        }
+
+        return new PairingInfoBooksTriple(parentBookInfoTriple, triples);
+    }
+
+    // [instance members] ******************************************************
+
+    /**
+     * コンストラクタ
+     *
+     * @param parentBookInfoTriple Excelブック情報（O, A, B）
+     * @param childSheetNameTriples シート名の組み合わせ
+     * @throws NullPointerException パラメータが {@code null} の場合
+     */
+    public PairingInfoBooksTriple {
+        Objects.requireNonNull(parentBookInfoTriple);
+        Objects.requireNonNull(childSheetNameTriples);
+
+        childSheetNameTriples = List.copyOf(childSheetNameTriples);
+    }
+}

--- a/xyz.hotchpotch.hogandiff/src/main/java/xyz/hotchpotch/hogandiff/logic/Result.java
+++ b/xyz.hotchpotch.hogandiff/src/main/java/xyz/hotchpotch/hogandiff/logic/Result.java
@@ -11,7 +11,7 @@ import xyz.hotchpotch.hogandiff.logic.ResultOfSheets.SheetStats;
  */
 // sealed を使ってみる
 public sealed interface Result
-        permits ResultOfSheets, ResultOfBooks, ResultOfDirs, ResultOfTrees {
+        permits ResultOfSheets, ResultOfSheetsTriple, ResultOfBooks, ResultOfBooksTriple, ResultOfDirs, ResultOfTrees {
     
     // [static members] ********************************************************
     

--- a/xyz.hotchpotch.hogandiff/src/main/java/xyz/hotchpotch/hogandiff/logic/ResultOfBooksTriple.java
+++ b/xyz.hotchpotch.hogandiff/src/main/java/xyz/hotchpotch/hogandiff/logic/ResultOfBooksTriple.java
@@ -6,8 +6,12 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Function;
 import java.util.function.Predicate;
+import java.util.stream.Collectors;
 
+import xyz.hotchpotch.hogandiff.logic.ResultOfSheets.Piece;
 import xyz.hotchpotch.hogandiff.logic.ResultOfSheets.SheetStats;
+import xyz.hotchpotch.hogandiff.logic.ResultOfSheetsTriple.OriginPieces;
+import xyz.hotchpotch.hogandiff.util.Pair;
 import xyz.hotchpotch.hogandiff.util.Triple;
 
 /**
@@ -181,6 +185,78 @@ public record ResultOfBooksTriple(
         str.append(getDiffDetail());
 
         return str.toString();
+    }
+
+    /**
+     * A ファイル着色用の差分情報を返します。<br>
+     * <p>
+     * キーは A 側のシート名、値は A 側の {@link Piece}（{@code Optional.empty()} は未比較）です。<br>
+     *
+     * @return A ファイル着色用差分情報（シート名 → Piece）
+     */
+    public Map<String, Optional<Piece>> getPieceForA() {
+        return sheetResults.entrySet().stream()
+                .filter(e -> e.getKey().hasA())
+                .collect(Collectors.toMap(
+                        e -> e.getKey().a(),
+                        e -> e.getValue().map(s -> s.getPiece(Triple.Side.A))));
+    }
+
+    /**
+     * B ファイル着色用の差分情報を返します。<br>
+     * <p>
+     * キーは B 側のシート名、値は B 側の {@link Piece}（{@code Optional.empty()} は未比較）です。<br>
+     *
+     * @return B ファイル着色用差分情報（シート名 → Piece）
+     */
+    public Map<String, Optional<Piece>> getPieceForB() {
+        return sheetResults.entrySet().stream()
+                .filter(e -> e.getKey().hasB())
+                .collect(Collectors.toMap(
+                        e -> e.getKey().b(),
+                        e -> e.getValue().map(s -> s.getPiece(Triple.Side.B))));
+    }
+
+    /**
+     * O ファイル着色用の A-only 差分情報を返します。<br>
+     * <p>
+     * キーは O 側のシート名、値は A のみで変更された箇所の {@link Piece} です。<br>
+     *
+     * @return O ファイル着色用 A-only 差分情報（シート名 → Piece）
+     */
+    public Map<String, Optional<Piece>> getPieceForOriginAOnly() {
+        return getOriginPieceMap(OriginPieces::aOnly);
+    }
+
+    /**
+     * O ファイル着色用の B-only 差分情報を返します。<br>
+     * <p>
+     * キーは O 側のシート名、値は B のみで変更された箇所の {@link Piece} です。<br>
+     *
+     * @return O ファイル着色用 B-only 差分情報（シート名 → Piece）
+     */
+    public Map<String, Optional<Piece>> getPieceForOriginBOnly() {
+        return getOriginPieceMap(OriginPieces::bOnly);
+    }
+
+    /**
+     * O ファイル着色用の競合差分情報を返します。<br>
+     * <p>
+     * キーは O 側のシート名、値は A・B 両方で変更された箇所の {@link Piece} です。<br>
+     *
+     * @return O ファイル着色用競合差分情報（シート名 → Piece）
+     */
+    public Map<String, Optional<Piece>> getPieceForOriginConflict() {
+        return getOriginPieceMap(OriginPieces::conflict);
+    }
+
+    private Map<String, Optional<Piece>> getOriginPieceMap(
+            Function<OriginPieces, Piece> pieceExtractor) {
+        return sheetResults.entrySet().stream()
+                .filter(e -> e.getKey().hasO())
+                .collect(Collectors.toMap(
+                        e -> e.getKey().o(),
+                        e -> e.getValue().map(s -> pieceExtractor.apply(s.computeOriginPieces()))));
     }
 
     @Override

--- a/xyz.hotchpotch.hogandiff/src/main/java/xyz/hotchpotch/hogandiff/logic/ResultOfBooksTriple.java
+++ b/xyz.hotchpotch.hogandiff/src/main/java/xyz/hotchpotch/hogandiff/logic/ResultOfBooksTriple.java
@@ -1,0 +1,195 @@
+package xyz.hotchpotch.hogandiff.logic;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.function.Predicate;
+
+import xyz.hotchpotch.hogandiff.logic.ResultOfSheets.SheetStats;
+import xyz.hotchpotch.hogandiff.util.Triple;
+
+/**
+ * Excelブックの3-way比較結果を表す不変クラスです。<br>
+ * <p>
+ * 起源（O）に対するA, Bの差分比較結果を保持します。<br>
+ *
+ * @param bookComparison Excelブック3-way比較情報
+ * @param sheetResults Excelシート同士の3-way比較結果（片側だけの欠損トリプルも含む）
+ * @author nmby
+ */
+public record ResultOfBooksTriple(
+        PairingInfoBooksTriple bookComparison,
+        Map<Triple<String>, Optional<ResultOfSheetsTriple>> sheetResults)
+        implements Result {
+
+    // [static members] ********************************************************
+
+    private static final String BR = System.lineSeparator();
+
+    /**
+     * シート名トリプルをユーザー表示用に整形して返します。<br>
+     *
+     * @param id シート名トリプルの識別子
+     * @param sheetNameTriple シート名トリプル
+     * @return シート名トリプルの整形済み文字列
+     * @throws NullPointerException パラメータが {@code null} の場合
+     */
+    public static String formatSheetNamesTriple(
+            String id,
+            Triple<String> sheetNameTriple) {
+
+        Objects.requireNonNull(id);
+        Objects.requireNonNull(sheetNameTriple);
+
+        return "    %s) %s  vs  %s  vs  %s".formatted(
+                id,
+                sheetNameTriple.hasO() ? "O[ " + sheetNameTriple.o() + " ]" : "(なし)",
+                sheetNameTriple.hasA() ? "A[ " + sheetNameTriple.a() + " ]" : "(なし)",
+                sheetNameTriple.hasB() ? "B[ " + sheetNameTriple.b() + " ]" : "(なし)");
+    }
+
+    // [instance members] ******************************************************
+
+    /**
+     * コンストラクタ<br>
+     *
+     * @param bookComparison Excelブック3-way比較情報
+     * @param sheetResults Excelシート同士の3-way比較結果（片側だけの欠損トリプルも含む）
+     * @throws NullPointerException パラメータが {@code null} の場合
+     */
+    public ResultOfBooksTriple {
+        Objects.requireNonNull(bookComparison);
+        Objects.requireNonNull(sheetResults);
+
+        sheetResults = Map.copyOf(sheetResults);
+    }
+
+    /**
+     * この比較結果における差分の有無を返します。<br>
+     *
+     * @return 差分ありの場合は {@code true}
+     */
+    public boolean hasDiff() {
+        return bookComparison.childSheetNameTriples().stream()
+                .map(sheetResults::get)
+                .anyMatch(r -> r == null || r.isEmpty() || r.get().hasDiff());
+    }
+
+    /**
+     * 比較結果を端的に表す差分サマリを返します。<br>
+     *
+     * @return 比較結果を端的に表す差分サマリ
+     */
+    public String getDiffSimpleSummary() {
+        int diffSheets = (int) bookComparison.childSheetNameTriples().stream()
+                .filter(Triple::isPaired)
+                .map(sheetResults::get)
+                .map(Optional::get)
+                .filter(ResultOfSheetsTriple::hasDiff)
+                .count();
+        int gapSheets = (int) bookComparison.childSheetNameTriples().stream()
+                .filter(Predicate.not(Triple::isPaired))
+                .count();
+
+        if (diffSheets == 0 && gapSheets == 0) {
+            return "差分なし";
+        }
+
+        StringBuilder str = new StringBuilder();
+        if (0 < diffSheets) {
+            str.append("%dシートに差分あり".formatted(diffSheets));
+        }
+        if (0 < gapSheets) {
+            if (!str.isEmpty()) {
+                str.append(", ");
+            }
+            str.append("%dシートが片側のみに存在".formatted(gapSheets));
+        }
+        return str.toString();
+    }
+
+    /**
+     * 比較結果の差分サマリを返します。<br>
+     *
+     * @return 比較結果の差分サマリ
+     */
+    public String getDiffSummary() {
+        return getDiffText(sResult -> "  -  " + sResult.getDiffSummary());
+    }
+
+    /**
+     * 比較結果の差分詳細を返します。<br>
+     *
+     * @return 比較結果の差分詳細
+     */
+    public String getDiffDetail() {
+        return getDiffText(sResult -> BR + sResult.getDiffDetail().indent(8).replace("\n", BR));
+    }
+
+    private String getDiffText(Function<ResultOfSheetsTriple, String> diffDescriptor) {
+        StringBuilder str = new StringBuilder();
+
+        for (int i = 0; i < bookComparison.childSheetNameTriples().size(); i++) {
+            Triple<String> sheetNameTriple = bookComparison.childSheetNameTriples().get(i);
+            Optional<ResultOfSheetsTriple> sResult = sheetResults.get(sheetNameTriple);
+
+            if (sResult == null || !sheetNameTriple.isPaired()
+                    || sResult.isEmpty() || !sResult.get().hasDiff()) {
+                continue;
+            }
+
+            str.append(formatSheetNamesTriple(Integer.toString(i + 1), sheetNameTriple));
+            str.append(diffDescriptor.apply(sResult.get()));
+            str.append(BR);
+        }
+
+        return str.isEmpty()
+                ? "    差分なし" + BR + BR
+                : str.toString();
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder str = new StringBuilder();
+
+        Triple<BookInfo> bookInfoTriple = bookComparison.parentBookInfoTriple();
+        if (bookInfoTriple.isIdentical()) {
+            str.append("ブック: ").append(bookInfoTriple.o().bookPath()).append(BR);
+        } else {
+            if (bookInfoTriple.hasO()) {
+                str.append("[O] ").append(bookInfoTriple.o().bookPath()).append(BR);
+            }
+            if (bookInfoTriple.hasA()) {
+                str.append("[A] ").append(bookInfoTriple.a().bookPath()).append(BR);
+            }
+            if (bookInfoTriple.hasB()) {
+                str.append("[B] ").append(bookInfoTriple.b().bookPath()).append(BR);
+            }
+        }
+
+        for (int i = 0; i < bookComparison.childSheetNameTriples().size(); i++) {
+            Triple<String> sheetNameTriple = bookComparison.childSheetNameTriples().get(i);
+            str.append(formatSheetNamesTriple(Integer.toString(i + 1), sheetNameTriple)).append(BR);
+        }
+
+        str.append(BR);
+        str.append("=== 差分サマリ ===").append(BR);
+        str.append(getDiffSummary()).append(BR);
+        str.append("=== 差分詳細 ===").append(BR);
+        str.append(getDiffDetail());
+
+        return str.toString();
+    }
+
+    @Override
+    public List<SheetStats> sheetStats() {
+        return sheetResults.values().stream()
+                .filter(Optional::isPresent)
+                .map(Optional::get)
+                .map(ResultOfSheetsTriple::sheetStats)
+                .flatMap(List::stream)
+                .toList();
+    }
+}

--- a/xyz.hotchpotch.hogandiff/src/main/java/xyz/hotchpotch/hogandiff/logic/ResultOfSheetsTriple.java
+++ b/xyz.hotchpotch.hogandiff/src/main/java/xyz/hotchpotch/hogandiff/logic/ResultOfSheetsTriple.java
@@ -1,0 +1,165 @@
+package xyz.hotchpotch.hogandiff.logic;
+
+import java.util.List;
+import java.util.Objects;
+
+import xyz.hotchpotch.hogandiff.logic.ResultOfSheets.Piece;
+import xyz.hotchpotch.hogandiff.logic.ResultOfSheets.SheetStats;
+import xyz.hotchpotch.hogandiff.util.Pair;
+import xyz.hotchpotch.hogandiff.util.Triple;
+
+/**
+ * Excelシートの3-way比較結果を表す不変クラスです。<br>
+ * <p>
+ * 起源（O）に対するA, Bそれぞれの2-way比較結果（O vs A、O vs B）を保持します。<br>
+ *
+ * @author nmby
+ */
+public final class ResultOfSheetsTriple implements Result {
+
+    // [static members] ********************************************************
+
+    private static final String BR = System.lineSeparator();
+
+    // [instance members] ******************************************************
+
+    /**
+     * O vs A の比較結果。<br>
+     * Pair.Side.A が O 側、Pair.Side.B が A 側に対応します。
+     */
+    private final ResultOfSheets resultOA;
+
+    /**
+     * O vs B の比較結果。<br>
+     * Pair.Side.A が O 側、Pair.Side.B が B 側に対応します。
+     */
+    private final ResultOfSheets resultOB;
+
+    /**
+     * コンストラクタ<br>
+     *
+     * @param resultOA O vs A の比較結果（Pair.Side.A = O, Pair.Side.B = A）
+     * @param resultOB O vs B の比較結果（Pair.Side.A = O, Pair.Side.B = B）
+     * @throws NullPointerException パラメータが {@code null} の場合
+     */
+    public ResultOfSheetsTriple(
+            ResultOfSheets resultOA,
+            ResultOfSheets resultOB) {
+
+        Objects.requireNonNull(resultOA);
+        Objects.requireNonNull(resultOB);
+
+        this.resultOA = resultOA;
+        this.resultOB = resultOB;
+    }
+
+    /**
+     * O vs A の比較結果を返します。<br>
+     *
+     * @return O vs A の比較結果
+     */
+    public ResultOfSheets resultOA() {
+        return resultOA;
+    }
+
+    /**
+     * O vs B の比較結果を返します。<br>
+     *
+     * @return O vs B の比較結果
+     */
+    public ResultOfSheets resultOB() {
+        return resultOB;
+    }
+
+    /**
+     * 指定された側のシートに関する差分内容を返します。<br>
+     * <p>
+     * <ul>
+     * <li>O側：AおよびBとの差分をすべて含む {@link Piece} を返します。</li>
+     * <li>A側：O vs A 比較のA側 {@link Piece} を返します。</li>
+     * <li>B側：O vs B 比較のB側 {@link Piece} を返します。</li>
+     * </ul>
+     *
+     * @param side シートの側
+     * @return 指定された側のシートに関する差分内容
+     * @throws NullPointerException パラメータが {@code null} の場合
+     */
+    public Piece getPiece(Triple.Side side) {
+        Objects.requireNonNull(side);
+
+        return switch (side) {
+            case O -> resultOA.getPiece(Pair.Side.A);
+            case A -> resultOA.getPiece(Pair.Side.B);
+            case B -> resultOB.getPiece(Pair.Side.B);
+        };
+    }
+
+    /**
+     * この比較結果における差分の有無を返します。<br>
+     *
+     * @return 差分ありの場合は {@code true}
+     */
+    public boolean hasDiff() {
+        return resultOA.hasDiff() || resultOB.hasDiff();
+    }
+
+    /**
+     * 比較結果の差分サマリを返します。<br>
+     *
+     * @return 比較結果の差分サマリ
+     */
+    public String getDiffSummary() {
+        if (!hasDiff()) {
+            return "差分なし";
+        }
+
+        StringBuilder str = new StringBuilder();
+        if (resultOA.hasDiff()) {
+            str.append("O vs A: ").append(resultOA.getDiffSummary());
+        }
+        if (resultOB.hasDiff()) {
+            if (!str.isEmpty()) {
+                str.append("  /  ");
+            }
+            str.append("O vs B: ").append(resultOB.getDiffSummary());
+        }
+        return str.toString();
+    }
+
+    /**
+     * 比較結果の差分詳細を返します。<br>
+     *
+     * @return 比較結果の差分詳細
+     */
+    public String getDiffDetail() {
+        if (!hasDiff()) {
+            return "差分なし";
+        }
+
+        StringBuilder str = new StringBuilder();
+        if (resultOA.hasDiff()) {
+            str.append("[O vs A]").append(BR);
+            str.append(resultOA.getDiffDetail());
+        }
+        if (resultOB.hasDiff()) {
+            if (!str.isEmpty()) {
+                str.append(BR);
+            }
+            str.append("[O vs B]").append(BR);
+            str.append(resultOB.getDiffDetail());
+        }
+        return str.toString();
+    }
+
+    @Override
+    public String toString() {
+        return getDiffDetail();
+    }
+
+    @Override
+    public List<SheetStats> sheetStats() {
+        return List.of(
+                resultOA.sheetStats().get(0),
+                resultOB.sheetStats().get(0));
+    }
+}

--- a/xyz.hotchpotch.hogandiff/src/main/java/xyz/hotchpotch/hogandiff/logic/ResultOfSheetsTriple.java
+++ b/xyz.hotchpotch.hogandiff/src/main/java/xyz/hotchpotch/hogandiff/logic/ResultOfSheetsTriple.java
@@ -1,7 +1,10 @@
 package xyz.hotchpotch.hogandiff.logic;
 
+import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import xyz.hotchpotch.hogandiff.logic.ResultOfSheets.Piece;
 import xyz.hotchpotch.hogandiff.logic.ResultOfSheets.SheetStats;
@@ -18,6 +21,18 @@ import xyz.hotchpotch.hogandiff.util.Triple;
 public final class ResultOfSheetsTriple implements Result {
 
     // [static members] ********************************************************
+
+    /**
+     * O ファイル着色用に分類した 3 種類の {@link Piece} を保持するレコードです。<br>
+     *
+     * @param aOnly    A のみで変更された差分（O ファイル上で赤系に着色）
+     * @param bOnly    B のみで変更された差分（O ファイル上で青系に着色）
+     * @param conflict A と B の両方で変更された差分（O ファイル上で紫系に着色）
+     */
+    public record OriginPieces(
+            Piece aOnly,
+            Piece bOnly,
+            Piece conflict) {}
 
     private static final String BR = System.lineSeparator();
 
@@ -149,6 +164,105 @@ public final class ResultOfSheetsTriple implements Result {
             str.append(resultOB.getDiffDetail());
         }
         return str.toString();
+    }
+
+    /**
+     * O ファイル着色用に差分を A-only / B-only / conflict に分類して返します。<br>
+     * <p>
+     * 差分の座標はいずれも O 座標系で表されます。<br>
+     *
+     * @return O ファイル着色用に分類した差分情報
+     */
+    public OriginPieces computeOriginPieces() {
+        // O の視点（Pair.Side.A = O 側）で両比較から Piece を取得する
+        Piece oPieceFromA = resultOA.getPiece(Pair.Side.A);
+        Piece oPieceFromB = resultOB.getPiece(Pair.Side.A);
+
+        // (row, column) 位置を表すローカルレコード
+        record Pos(int row, int col) {}
+
+        // --- 余剰行 ---
+        Set<Integer> aRows = new HashSet<>(oPieceFromA.redundantRows());
+        Set<Integer> bRows = new HashSet<>(oPieceFromB.redundantRows());
+        Set<Integer> conflictRows = aRows.stream()
+                .filter(bRows::contains)
+                .collect(Collectors.toSet());
+        List<Integer> aOnlyRows = oPieceFromA.redundantRows().stream()
+                .filter(r -> !conflictRows.contains(r)).toList();
+        List<Integer> bOnlyRows = oPieceFromB.redundantRows().stream()
+                .filter(r -> !conflictRows.contains(r)).toList();
+        List<Integer> conflictRowList = oPieceFromA.redundantRows().stream()
+                .filter(conflictRows::contains).toList();
+
+        // --- 余剰列 ---
+        Set<Integer> aCols = new HashSet<>(oPieceFromA.redundantColumns());
+        Set<Integer> bCols = new HashSet<>(oPieceFromB.redundantColumns());
+        Set<Integer> conflictCols = aCols.stream()
+                .filter(bCols::contains)
+                .collect(Collectors.toSet());
+        List<Integer> aOnlyCols = oPieceFromA.redundantColumns().stream()
+                .filter(c -> !conflictCols.contains(c)).toList();
+        List<Integer> bOnlyCols = oPieceFromB.redundantColumns().stream()
+                .filter(c -> !conflictCols.contains(c)).toList();
+        List<Integer> conflictColList = oPieceFromA.redundantColumns().stream()
+                .filter(conflictCols::contains).toList();
+
+        // --- 差分セル内容 ---
+        Set<Pos> aContentPos = oPieceFromA.diffCellContents().stream()
+                .map(c -> new Pos(c.row(), c.column()))
+                .collect(Collectors.toSet());
+        Set<Pos> bContentPos = oPieceFromB.diffCellContents().stream()
+                .map(c -> new Pos(c.row(), c.column()))
+                .collect(Collectors.toSet());
+        Set<Pos> conflictContentPos = aContentPos.stream()
+                .filter(bContentPos::contains)
+                .collect(Collectors.toSet());
+        List<CellData> aOnlyContents = oPieceFromA.diffCellContents().stream()
+                .filter(c -> !conflictContentPos.contains(new Pos(c.row(), c.column()))).toList();
+        List<CellData> bOnlyContents = oPieceFromB.diffCellContents().stream()
+                .filter(c -> !conflictContentPos.contains(new Pos(c.row(), c.column()))).toList();
+        List<CellData> conflictContents = oPieceFromA.diffCellContents().stream()
+                .filter(c -> conflictContentPos.contains(new Pos(c.row(), c.column()))).toList();
+
+        // --- 差分セルコメント ---
+        Set<Pos> aCommentPos = oPieceFromA.diffCellComments().stream()
+                .map(c -> new Pos(c.row(), c.column()))
+                .collect(Collectors.toSet());
+        Set<Pos> bCommentPos = oPieceFromB.diffCellComments().stream()
+                .map(c -> new Pos(c.row(), c.column()))
+                .collect(Collectors.toSet());
+        Set<Pos> conflictCommentPos = aCommentPos.stream()
+                .filter(bCommentPos::contains)
+                .collect(Collectors.toSet());
+        List<CellData> aOnlyComments = oPieceFromA.diffCellComments().stream()
+                .filter(c -> !conflictCommentPos.contains(new Pos(c.row(), c.column()))).toList();
+        List<CellData> bOnlyComments = oPieceFromB.diffCellComments().stream()
+                .filter(c -> !conflictCommentPos.contains(new Pos(c.row(), c.column()))).toList();
+        List<CellData> conflictComments = oPieceFromA.diffCellComments().stream()
+                .filter(c -> conflictCommentPos.contains(new Pos(c.row(), c.column()))).toList();
+
+        // --- 余剰セルコメント ---
+        Set<Pos> aRedundantComPos = oPieceFromA.redundantCellComments().stream()
+                .map(c -> new Pos(c.row(), c.column()))
+                .collect(Collectors.toSet());
+        Set<Pos> bRedundantComPos = oPieceFromB.redundantCellComments().stream()
+                .map(c -> new Pos(c.row(), c.column()))
+                .collect(Collectors.toSet());
+        Set<Pos> conflictRedundantComPos = aRedundantComPos.stream()
+                .filter(bRedundantComPos::contains)
+                .collect(Collectors.toSet());
+        List<CellData> aOnlyRedundantComs = oPieceFromA.redundantCellComments().stream()
+                .filter(c -> !conflictRedundantComPos.contains(new Pos(c.row(), c.column()))).toList();
+        List<CellData> bOnlyRedundantComs = oPieceFromB.redundantCellComments().stream()
+                .filter(c -> !conflictRedundantComPos.contains(new Pos(c.row(), c.column()))).toList();
+        List<CellData> conflictRedundantComs = oPieceFromA.redundantCellComments().stream()
+                .filter(c -> conflictRedundantComPos.contains(new Pos(c.row(), c.column()))).toList();
+
+        return new OriginPieces(
+                new Piece(aOnlyRows, aOnlyCols, aOnlyContents, aOnlyComments, aOnlyRedundantComs),
+                new Piece(bOnlyRows, bOnlyCols, bOnlyContents, bOnlyComments, bOnlyRedundantComs),
+                new Piece(conflictRowList, conflictColList, conflictContents, conflictComments,
+                        conflictRedundantComs));
     }
 
     @Override

--- a/xyz.hotchpotch.hogandiff/src/main/java/xyz/hotchpotch/hogandiff/tasks/CompareTask.java
+++ b/xyz.hotchpotch.hogandiff/src/main/java/xyz/hotchpotch/hogandiff/tasks/CompareTask.java
@@ -46,7 +46,7 @@ import xyz.hotchpotch.hogandiff.util.Settings;
  * @author nmby
  */
 /* package */ abstract sealed class CompareTask extends Task<Void>
-        permits CompareTaskSheets, CompareTaskBooks, CompareTaskDirs, CompareTaskTrees {
+        permits CompareTaskSheets, CompareTaskBooks, CompareTaskBooksTriple, CompareTaskDirs, CompareTaskTrees {
     
     // [static members] ********************************************************
     

--- a/xyz.hotchpotch.hogandiff/src/main/java/xyz/hotchpotch/hogandiff/tasks/CompareTaskBooksTriple.java
+++ b/xyz.hotchpotch.hogandiff/src/main/java/xyz/hotchpotch/hogandiff/tasks/CompareTaskBooksTriple.java
@@ -1,0 +1,404 @@
+package xyz.hotchpotch.hogandiff.tasks;
+
+import java.awt.Color;
+import java.awt.Desktop;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+import xyz.hotchpotch.hogandiff.ApplicationException;
+import xyz.hotchpotch.hogandiff.ErrorReporter;
+import xyz.hotchpotch.hogandiff.Msg;
+import xyz.hotchpotch.hogandiff.SettingKeys;
+import xyz.hotchpotch.hogandiff.logic.BookInfo;
+import xyz.hotchpotch.hogandiff.logic.CellData;
+import xyz.hotchpotch.hogandiff.logic.CellsLoader;
+import xyz.hotchpotch.hogandiff.logic.ComparatorOfSheets;
+import xyz.hotchpotch.hogandiff.logic.Factory;
+import xyz.hotchpotch.hogandiff.logic.PairingInfoBooksTriple;
+import xyz.hotchpotch.hogandiff.logic.Painter;
+import xyz.hotchpotch.hogandiff.logic.Result;
+import xyz.hotchpotch.hogandiff.logic.ResultOfBooksTriple;
+import xyz.hotchpotch.hogandiff.logic.ResultOfSheets;
+import xyz.hotchpotch.hogandiff.logic.ResultOfSheetsTriple;
+import xyz.hotchpotch.hogandiff.util.Pair;
+import xyz.hotchpotch.hogandiff.util.Settings;
+import xyz.hotchpotch.hogandiff.util.Triple;
+import xyz.hotchpotch.hogandiff.util.Triple.Side;
+
+/**
+ * Excelブックの 3-way 比較処理を実行するためのタスクです。<br>
+ * <br>
+ * <strong>注意：</strong><br>
+ * このタスクは、いわゆるワンショットです。
+ * 同一インスタンスのタスクを複数回実行しないでください。<br>
+ *
+ * @author nmby
+ */
+public final class CompareTaskBooksTriple extends CompareTask {
+
+    // [static members] ********************************************************
+
+    // [instance members] ******************************************************
+
+    /**
+     * コンストラクタ
+     *
+     * @param settings 設定セット
+     */
+    public CompareTaskBooksTriple(Settings settings) {
+        super(settings);
+    }
+
+    @Override
+    protected Result call2() throws ApplicationException {
+        try {
+            // 0. 処理開始のアナウンス
+            announceStart(0, 3);
+
+            // 1. シート同士の比較
+            ResultOfBooksTriple bResult = compareSheets(3, 75);
+
+            Exception failed = null;
+
+            // 2. 差分箇所への着色と表示
+            try {
+                paintSaveAndShowBooks(bResult, 75, 95);
+            } catch (Exception e) {
+                failed = e;
+            }
+
+            // 3. 比較結果レポート（テキスト）の保存
+            try {
+                saveResultText(workDir, bResult.toString(), 95, 98);
+            } catch (Exception e) {
+                if (failed == null) {
+                    failed = e;
+                } else {
+                    failed.addSuppressed(e);
+                }
+            }
+
+            // 4. 処理終了のアナウンス
+            announceEnd();
+
+            if (failed != null) {
+                throw failed;
+            }
+
+            return bResult;
+
+        } catch (Exception e) {
+            throw getApplicationException(e, Msg.APP_0150.get() + " at CompareTaskBooksTriple::call2");
+        }
+    }
+
+    // ■ タスクステップ ■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■
+
+    // 0. 処理開始のアナウンス
+    private void announceStart(
+            int progressBefore,
+            int progressAfter)
+            throws ApplicationException {
+
+        try {
+            updateProgress(progressBefore, PROGRESS_MAX);
+
+            PairingInfoBooksTriple pairingInfo = settings.get(SettingKeys.CURR_BOOK_COMPARE_INFO_TRIPLE);
+            Triple<String> dispPathTriple = pairingInfo.parentBookInfoTriple().map(BookInfo::dispPathInfo);
+
+            str.append("%s%n[O] %s%n[A] %s%n[B] %s%n"
+                    .formatted(Msg.APP_0170.get(),
+                            dispPathTriple.o(), dispPathTriple.a(), dispPathTriple.b()));
+
+            for (int i = 0; i < pairingInfo.childSheetNameTriples().size(); i++) {
+                Triple<String> sheetNameTriple = pairingInfo.childSheetNameTriples().get(i);
+                str.append(ResultOfBooksTriple.formatSheetNamesTriple(
+                        Integer.toString(i + 1), sheetNameTriple)).append(BR);
+            }
+
+            str.append(BR);
+            updateMessage(str.toString());
+            updateProgress(progressAfter, PROGRESS_MAX);
+
+        } catch (Exception e) {
+            throw getApplicationException(e, Msg.APP_0150.get() + " at CompareTaskBooksTriple::announceStart");
+        }
+    }
+
+    // 1. シート同士の比較
+    private ResultOfBooksTriple compareSheets(
+            int progressBefore,
+            int progressAfter)
+            throws ApplicationException {
+
+        try {
+            updateProgress(progressBefore, PROGRESS_MAX);
+            str.append(Msg.APP_0180.get()).append(BR);
+            updateMessage(str.toString());
+
+            PairingInfoBooksTriple pairingInfo = settings.get(SettingKeys.CURR_BOOK_COMPARE_INFO_TRIPLE);
+            Triple<BookInfo> bookInfoTriple = pairingInfo.parentBookInfoTriple();
+
+            Triple<CellsLoader> loaderTriple = bookInfoTriple
+                    .unsafeMap(bookInfo -> Factory.cellsLoader(settings, bookInfo));
+
+            ComparatorOfSheets sheetComparator = Factory.sheetComparator(settings);
+            Map<Path, String> readPasswords = settings.get(SettingKeys.CURR_READ_PASSWORDS);
+            Map<Triple<String>, Optional<ResultOfSheetsTriple>> results = new HashMap<>();
+
+            double progressDelta = (progressAfter - progressBefore)
+                    / (double) pairingInfo.childSheetNameTriples().size();
+
+            for (int i = 0; i < pairingInfo.childSheetNameTriples().size(); i++) {
+                Triple<String> sheetNameTriple = pairingInfo.childSheetNameTriples().get(i);
+                ResultOfSheetsTriple result = null;
+
+                try {
+                    if (sheetNameTriple.isPaired()) {
+                        str.append(ResultOfBooksTriple.formatSheetNamesTriple(
+                                Integer.toString(i + 1), sheetNameTriple));
+                        updateMessage(str.toString());
+
+                        // O vs A の比較
+                        BookInfo bookInfoO = bookInfoTriple.o();
+                        BookInfo bookInfoA = bookInfoTriple.a();
+                        BookInfo bookInfoB = bookInfoTriple.b();
+
+                        Set<CellData> cellsO_forA = loaderTriple.o().loadCells(
+                                bookInfoO,
+                                readPasswords.get(bookInfoO.bookPath()),
+                                sheetNameTriple.o());
+                        Set<CellData> cellsA = loaderTriple.a().loadCells(
+                                bookInfoA,
+                                readPasswords.get(bookInfoA.bookPath()),
+                                sheetNameTriple.a());
+                        ResultOfSheets resultOA = sheetComparator.compare(Pair.of(cellsO_forA, cellsA));
+
+                        // O vs B の比較
+                        Set<CellData> cellsO_forB = loaderTriple.o().loadCells(
+                                bookInfoO,
+                                readPasswords.get(bookInfoO.bookPath()),
+                                sheetNameTriple.o());
+                        Set<CellData> cellsB = loaderTriple.b().loadCells(
+                                bookInfoB,
+                                readPasswords.get(bookInfoB.bookPath()),
+                                sheetNameTriple.b());
+                        ResultOfSheets resultOB = sheetComparator.compare(Pair.of(cellsO_forB, cellsB));
+
+                        result = new ResultOfSheetsTriple(resultOA, resultOB);
+
+                        str.append("  -  ").append(result.getDiffSummary()).append(BR);
+                        updateMessage(str.toString());
+                    }
+                } catch (Exception e) {
+                    str.append("  -  ").append(Msg.APP_0120.get()).append(BR);
+                    ErrorReporter.reportIfEnabled(e, "CompareTaskBooksTriple::compareSheets-1");
+                }
+
+                results.put(sheetNameTriple, Optional.ofNullable(result));
+                updateProgress(progressBefore + progressDelta * (i + 1), PROGRESS_MAX);
+            }
+
+            str.append(BR);
+            updateMessage(str.toString());
+            updateProgress(progressAfter, PROGRESS_MAX);
+
+            return new ResultOfBooksTriple(pairingInfo, results);
+
+        } catch (Exception e) {
+            throw getApplicationException(e, Msg.APP_0190.get());
+        }
+    }
+
+    // 2. 差分箇所への着色と表示
+    private void paintSaveAndShowBooks(
+            ResultOfBooksTriple bResult,
+            int progressBefore,
+            int progressAfter)
+            throws ApplicationException {
+
+        ApplicationException thrown = null;
+
+        try {
+            updateProgress(progressBefore, PROGRESS_MAX);
+            str.append(Msg.APP_0050.get()).append(BR);
+            updateMessage(str.toString());
+
+            PairingInfoBooksTriple pairingInfo = settings.get(SettingKeys.CURR_BOOK_COMPARE_INFO_TRIPLE);
+            Triple<BookInfo> bookInfoTriple = pairingInfo.parentBookInfoTriple();
+            Map<Path, String> readPasswords = settings.get(SettingKeys.CURR_READ_PASSWORDS);
+
+            // 出力ファイルパス
+            Path dstA = workDir.resolve(
+                    "【A】" + bookInfoTriple.a().bookNameWithExtension());
+            Path dstB = workDir.resolve(
+                    "【B】" + bookInfoTriple.b().bookNameWithExtension());
+            Path dstO = workDir.resolve(
+                    "【O】" + bookInfoTriple.o().bookNameWithExtension());
+            Path dstOTmp1 = workDir.resolve(
+                    "【O_tmp1】" + bookInfoTriple.o().bookNameWithExtension());
+            Path dstOTmp2 = workDir.resolve(
+                    "【O_tmp2】" + bookInfoTriple.o().bookNameWithExtension());
+
+            Path srcA = bookInfoTriple.a().bookPath();
+            Path srcB = bookInfoTriple.b().bookPath();
+            Path srcO = bookInfoTriple.o().bookPath();
+            String pwdA = readPasswords.get(srcA);
+            String pwdB = readPasswords.get(srcB);
+            String pwdO = readPasswords.get(srcO);
+
+            // A ファイル着色（既存の DIFF_COLOR を使用）
+            try {
+                str.append("    - %s%n".formatted(dstA));
+                updateMessage(str.toString());
+
+                Painter painterA = Factory.painter(settings, dstA, pwdA);
+                painterA.paintAndSave(srcA, dstA, pwdA, bResult.getPieceForA());
+                updateProgress(
+                        progressBefore + (progressAfter - progressBefore) * 1 / 5,
+                        PROGRESS_MAX);
+            } catch (Exception e) {
+                ApplicationException ee = getApplicationException(e,
+                        Msg.APP_0090.get().formatted("A"));
+                if (thrown == null) {
+                    thrown = ee;
+                } else {
+                    thrown.addSuppressed(ee);
+                }
+            }
+
+            // B ファイル着色（既存の DIFF_COLOR を使用）
+            try {
+                str.append("    - %s%n".formatted(dstB));
+                updateMessage(str.toString());
+
+                Painter painterB = Factory.painter(settings, dstB, pwdB);
+                painterB.paintAndSave(srcB, dstB, pwdB, bResult.getPieceForB());
+                updateProgress(
+                        progressBefore + (progressAfter - progressBefore) * 2 / 5,
+                        PROGRESS_MAX);
+            } catch (Exception e) {
+                ApplicationException ee = getApplicationException(e,
+                        Msg.APP_0090.get().formatted("B"));
+                if (thrown == null) {
+                    thrown = ee;
+                } else {
+                    thrown.addSuppressed(ee);
+                }
+            }
+
+            // O ファイル着色（3 パス）
+            try {
+                str.append("    - %s%n".formatted(dstO));
+                updateMessage(str.toString());
+
+                Color redundantCommentColor = settings.get(SettingKeys.REDUNDANT_COMMENT_COLOR);
+                Color diffCommentColor = settings.get(SettingKeys.DIFF_COMMENT_COLOR);
+                String redundantCommentHex = SettingKeys.REDUNDANT_COMMENT_COLOR.encoder()
+                        .apply(redundantCommentColor);
+                String diffCommentHex = SettingKeys.DIFF_COMMENT_COLOR.encoder()
+                        .apply(diffCommentColor);
+                Color redundantSheetColor = settings.get(SettingKeys.REDUNDANT_SHEET_COLOR);
+                Color diffSheetColor = settings.get(SettingKeys.DIFF_SHEET_COLOR);
+                Color sameSheetColor = settings.get(SettingKeys.SAME_SHEET_COLOR);
+
+                // パス1: A-only 差分を赤系（THREE_WAY_DIFF_COLOR_A）で着色
+                short colorA = settings.get(SettingKeys.THREE_WAY_DIFF_COLOR_A);
+                Painter painterOA = Painter.of(
+                        dstOTmp1, pwdO,
+                        colorA, colorA,
+                        redundantCommentColor, diffCommentColor,
+                        redundantCommentHex, diffCommentHex,
+                        redundantSheetColor, diffSheetColor, sameSheetColor);
+                painterOA.paintAndSave(srcO, dstOTmp1, pwdO, bResult.getPieceForOriginAOnly());
+
+                updateProgress(
+                        progressBefore + (progressAfter - progressBefore) * 3 / 5,
+                        PROGRESS_MAX);
+
+                // パス2: B-only 差分を青系（THREE_WAY_DIFF_COLOR_B）で着色
+                short colorB = settings.get(SettingKeys.THREE_WAY_DIFF_COLOR_B);
+                Painter painterOB = Painter.of(
+                        dstOTmp2, pwdO,
+                        colorB, colorB,
+                        redundantCommentColor, diffCommentColor,
+                        redundantCommentHex, diffCommentHex,
+                        redundantSheetColor, diffSheetColor, sameSheetColor);
+                painterOB.paintAndSave(dstOTmp1, dstOTmp2, pwdO, bResult.getPieceForOriginBOnly());
+
+                updateProgress(
+                        progressBefore + (progressAfter - progressBefore) * 4 / 5,
+                        PROGRESS_MAX);
+
+                // パス3: 競合差分を紫系（THREE_WAY_DIFF_COLOR_CONFLICT）で着色
+                short colorConflict = settings.get(SettingKeys.THREE_WAY_DIFF_COLOR_CONFLICT);
+                Painter painterOConflict = Painter.of(
+                        dstO, pwdO,
+                        colorConflict, colorConflict,
+                        redundantCommentColor, diffCommentColor,
+                        redundantCommentHex, diffCommentHex,
+                        redundantSheetColor, diffSheetColor, sameSheetColor);
+                painterOConflict.paintAndSave(dstOTmp2, dstO, pwdO, bResult.getPieceForOriginConflict());
+
+                // 中間ファイルを削除
+                try {
+                    Files.deleteIfExists(dstOTmp1);
+                } catch (Exception e) {
+                    ErrorReporter.reportIfEnabled(e, "CompareTaskBooksTriple::paintSaveAndShowBooks-tmp1");
+                }
+                try {
+                    Files.deleteIfExists(dstOTmp2);
+                } catch (Exception e) {
+                    ErrorReporter.reportIfEnabled(e, "CompareTaskBooksTriple::paintSaveAndShowBooks-tmp2");
+                }
+
+            } catch (Exception e) {
+                ApplicationException ee = getApplicationException(e,
+                        Msg.APP_0090.get().formatted("O"));
+                if (thrown == null) {
+                    thrown = ee;
+                } else {
+                    thrown.addSuppressed(ee);
+                }
+            }
+
+            // 着色済みファイルを表示
+            try {
+                if (settings.get(SettingKeys.SHOW_PAINTED_SHEETS)) {
+                    str.append(BR).append(Msg.APP_0070.get()).append(BR).append(BR);
+                    updateMessage(str.toString());
+                    Desktop.getDesktop().open(dstA.toFile());
+                    Desktop.getDesktop().open(dstB.toFile());
+                    Desktop.getDesktop().open(dstO.toFile());
+                } else {
+                    str.append(BR);
+                }
+            } catch (Exception e) {
+                ApplicationException ee = getApplicationException(e, Msg.APP_0080.get());
+                if (thrown == null) {
+                    thrown = ee;
+                } else {
+                    thrown.addSuppressed(ee);
+                }
+            }
+
+            updateProgress(progressAfter, PROGRESS_MAX);
+
+        } catch (Exception e) {
+            ApplicationException ee = getApplicationException(e, Msg.APP_0060.get());
+            if (thrown == null) {
+                thrown = ee;
+            } else {
+                thrown.addSuppressed(ee);
+            }
+        }
+
+        if (thrown != null) {
+            throw thrown;
+        }
+    }
+}

--- a/xyz.hotchpotch.hogandiff/src/main/java/xyz/hotchpotch/hogandiff/util/Triple.java
+++ b/xyz.hotchpotch.hogandiff/src/main/java/xyz/hotchpotch/hogandiff/util/Triple.java
@@ -1,0 +1,319 @@
+package xyz.hotchpotch.hogandiff.util;
+
+import java.util.NoSuchElementException;
+import java.util.Objects;
+import java.util.function.Consumer;
+import java.util.function.Function;
+
+import xyz.hotchpotch.hogandiff.util.function.UnsafeFunction;
+
+/**
+ * 同型の3つの要素を保持する不変コンテナです。<br>
+ *
+ * @param <T> 要素の型
+ * @param o 起源（origin）の要素
+ * @param a 要素a
+ * @param b 要素b
+ * @author nmby
+ */
+public record Triple<T>(T o, T a, T b) {
+
+    // [static members] ********************************************************
+
+    /**
+     * トリプルのどの側かを表す列挙型です。<br>
+     *
+     * @author nmby
+     */
+    public static enum Side {
+
+        // [static members] ----------------------------------------------------
+
+        /** O-side（起源） */
+        O,
+
+        /** A-side */
+        A,
+
+        /** B-side */
+        B;
+
+        /**
+         * 各側に関数を適用して得られる要素からなるトリプルを返します。<br>
+         *
+         * @param <T> 新たな要素の型
+         * @param mapper 各側に適用する関数
+         * @return 新たなトリプル
+         * @throws NullPointerException パラメータが {@code null} の場合
+         */
+        public static <T> Triple<T> map(Function<Side, ? extends T> mapper) {
+            Objects.requireNonNull(mapper);
+
+            return new Triple<>(
+                    mapper.apply(O),
+                    mapper.apply(A),
+                    mapper.apply(B));
+        }
+
+        /**
+         * 各側に関数を適用して得られる要素からなるトリプルを返します。<br>
+         *
+         * @param <T> 新たな要素の型
+         * @param <E> {@code mapper} がスローしうるチェック例外の型
+         * @param mapper 各側に適用する関数
+         * @return 新たなトリプル
+         * @throws NullPointerException パラメータが {@code null} の場合
+         */
+        public static <T, E extends Exception> Triple<T> unsafeMap(
+                UnsafeFunction<Side, ? extends T, E> mapper) throws E {
+
+            Objects.requireNonNull(mapper);
+
+            return new Triple<>(
+                    mapper.apply(O),
+                    mapper.apply(A),
+                    mapper.apply(B));
+        }
+
+        /**
+         * 各側に指定されたオペレーションを適用します。<br>
+         *
+         * @param operation 各側に適用するオペレーション
+         * @throws NullPointerException パラメータが {@code null} の場合
+         */
+        public static void forEach(Consumer<Side> operation) {
+            Objects.requireNonNull(operation);
+
+            operation.accept(O);
+            operation.accept(A);
+            operation.accept(B);
+        }
+    }
+
+    /**
+     * 新しいトリプルを返します。<br>
+     *
+     * @param <T> 要素の型
+     * @param o 起源（origin）の要素
+     * @param a 要素a
+     * @param b 要素b
+     * @return 新しいトリプル
+     */
+    public static <T> Triple<T> of(T o, T a, T b) {
+        return new Triple<>(o, a, b);
+    }
+
+    /**
+     * 指定された側だけの要素を持つ新しいトリプルを返します。<br>
+     *
+     * @param <T> 要素の型
+     * @param side 要素の側
+     * @param value 指定された側の要素
+     * @return 新しいトリプル
+     * @throws NullPointerException {@code side} が {@code null} の場合
+     */
+    public static <T> Triple<T> ofOnly(Side side, T value) {
+        Objects.requireNonNull(side);
+        return switch (side) {
+            case O -> new Triple<>(value, null, null);
+            case A -> new Triple<>(null, value, null);
+            case B -> new Triple<>(null, null, value);
+        };
+    }
+
+    /**
+     * 空のトリプルを返します。<br>
+     *
+     * @param <T> 要素の型
+     * @return 空のトリプル
+     */
+    public static <T> Triple<T> empty() {
+        return new Triple<>(null, null, null);
+    }
+
+    // [instance members] ******************************************************
+
+    @Override
+    public String toString() {
+        return "(%s, %s, %s)".formatted(o, a, b);
+    }
+
+    /**
+     * 指定された側の要素がある場合はその値を返し、そうでない場合は例外をスローします。<br>
+     *
+     * @param side 要素の側
+     * @return 指定された側の要素
+     * @throws NullPointerException パラメータが {@code null} の場合
+     * @throws NoSuchElementException 指定された側の要素が無い場合
+     */
+    public T get(Side side) {
+        Objects.requireNonNull(side);
+
+        T value = switch (side) {
+            case O -> o;
+            case A -> a;
+            case B -> b;
+        };
+        if (value == null) {
+            throw new NoSuchElementException();
+        }
+        return value;
+    }
+
+    /**
+     * 要素oが存在するかを返します。<br>
+     *
+     * @return 要素oが存在する場合は {@code true}
+     */
+    public boolean hasO() {
+        return o != null;
+    }
+
+    /**
+     * 要素aが存在するかを返します。<br>
+     *
+     * @return 要素aが存在する場合は {@code true}
+     */
+    public boolean hasA() {
+        return a != null;
+    }
+
+    /**
+     * 要素bが存在するかを返します。<br>
+     *
+     * @return 要素bが存在する場合は {@code true}
+     */
+    public boolean hasB() {
+        return b != null;
+    }
+
+    /**
+     * 指定された側の要素が存在するかを返します。<br>
+     *
+     * @param side 要素の側
+     * @return 指定された側の要素が存在する場合は {@code true}
+     * @throws NullPointerException パラメータが {@code null} の場合
+     */
+    public boolean has(Side side) {
+        Objects.requireNonNull(side);
+
+        return switch (side) {
+            case O -> o != null;
+            case A -> a != null;
+            case B -> b != null;
+        };
+    }
+
+    /**
+     * 要素o, 要素a, 要素bがすべて存在するかを返します。<br>
+     *
+     * @return 全要素が存在する場合は {@code true}
+     */
+    public boolean isPaired() {
+        return o != null && a != null && b != null;
+    }
+
+    /**
+     * 要素oだけが存在するかを返します。<br>
+     *
+     * @return 要素oだけが存在する場合は {@code true}
+     */
+    public boolean isOnlyO() {
+        return o != null && a == null && b == null;
+    }
+
+    /**
+     * 要素aだけが存在するかを返します。<br>
+     *
+     * @return 要素aだけが存在する場合は {@code true}
+     */
+    public boolean isOnlyA() {
+        return o == null && a != null && b == null;
+    }
+
+    /**
+     * 要素bだけが存在するかを返します。<br>
+     *
+     * @return 要素bだけが存在する場合は {@code true}
+     */
+    public boolean isOnlyB() {
+        return o == null && a == null && b != null;
+    }
+
+    /**
+     * このトリプルが空かを返します。<br>
+     *
+     * @return このトリプルが空の場合は {@code true}
+     */
+    public boolean isEmpty() {
+        return o == null && a == null && b == null;
+    }
+
+    /**
+     * 要素o、要素a、要素bがすべて同じであるかを返します。<br>
+     *
+     * @return 全要素が同じ場合は {@code true}
+     */
+    public boolean isIdentical() {
+        return Objects.equals(o, a) && Objects.equals(a, b);
+    }
+
+    /**
+     * このトリプルの各要素に関数を適用して得られる新たな要素からなるトリプルを返します。<br>
+     *
+     * @param <U> 新たな要素の型
+     * @param mapper 各要素に適用する関数
+     * @return 新たなトリプル
+     * @throws NullPointerException パラメータが {@code null} の場合
+     */
+    public <U> Triple<U> map(Function<? super T, ? extends U> mapper) {
+        Objects.requireNonNull(mapper);
+
+        return new Triple<>(
+                o == null ? null : mapper.apply(o),
+                a == null ? null : mapper.apply(a),
+                b == null ? null : mapper.apply(b));
+    }
+
+    /**
+     * このトリプルの各要素に関数を適用して得られる新たな要素からなるトリプルを返します。<br>
+     *
+     * @param <U> 新たな要素の型
+     * @param <E> {@code mapper} がスローしうるチェック例外の型
+     * @param mapper 各要素に適用する関数
+     * @return 新たなトリプル
+     * @throws NullPointerException パラメータが {@code null} の場合
+     * @throws E {@code mapper.apply} が失敗した場合
+     */
+    public <U, E extends Exception> Triple<U> unsafeMap(
+            UnsafeFunction<? super T, ? extends U, E> mapper) throws E {
+
+        Objects.requireNonNull(mapper);
+
+        return new Triple<>(
+                o == null ? null : mapper.apply(o),
+                a == null ? null : mapper.apply(a),
+                b == null ? null : mapper.apply(b));
+    }
+
+    /**
+     * このトリプルの各要素に指定されたオペレーションを適用します。
+     * 要素が存在しない場合はオペレーションを適用しません。<br>
+     *
+     * @param operation 各要素に適用するオペレーション
+     * @throws NullPointerException パラメータが {@code null} の場合
+     */
+    public void forEach(Consumer<? super T> operation) {
+        Objects.requireNonNull(operation);
+
+        if (o != null) {
+            operation.accept(o);
+        }
+        if (a != null) {
+            operation.accept(a);
+        }
+        if (b != null) {
+            operation.accept(b);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- **`DiffMode` enum（新規）**: `TWO_WAY` / `THREE_WAY` の 2 値
- **`SettingKeys`（修正）**: `CURR_DIFF_MODE`、`CURR_BOOK_COMPARE_INFO_TRIPLE`、3-way 用着色設定 3 つ（A-only 赤系・B-only 青系・競合紫系）を追加
- **`AppMenu`（修正）**: `getTask()` / `isValidTargets()` が `Settings` から `DiffMode` を読んで 2-way / 3-way を切り替える（シグネチャ変更なし）
- **`ResultOfSheetsTriple`（修正）**: `OriginPieces` レコードと `computeOriginPieces()` を追加。O 座標系での差分を A-only / B-only / conflict に分類
- **`ResultOfBooksTriple`（修正）**: `getPieceForA/B` および `getPieceForOriginAOnly/BOnly/Conflict` を追加
- **`CompareTaskBooksTriple`（新規）**: 3-way ブック比較タスク本体
  - O vs A・O vs B をそれぞれ独立した 2-way 比較として実行（行ずれ考慮あり）
  - O ファイルは 3 パスで着色（赤 → 青 → 紫）、中間ファイルは自動削除
  - A・B ファイルは既存の `DIFF_COLOR`（黄）で着色

## Test plan

- [x] `../gradlew compileJava` でコンパイルエラーなし
- [x] `../gradlew test` でテスト全件パス
- [ ] GUI 接続（3-way モード選択、ファイル指定、比較実行）は次フェーズ

🤖 Generated with [Claude Code](https://claude.com/claude-code)